### PR TITLE
Niccolo

### DIFF
--- a/embedairr/antiberta2_embedder.py
+++ b/embedairr/antiberta2_embedder.py
@@ -220,27 +220,7 @@ class Antiberta2Embedder(BaseEmbedder):
                     f"Processed {len(self.sequence_labels)} out of {len(self.sequences)} sequences"
                 , end="\r")
                 
-
                 gc.collect()
-                # print(f"Memory footprint :{self.print_memory_footprint()}")
         print("Finished extracting embeddings")
 
 
-def write_batch(self, outputs, representations, batch_idx):
-    if self.extract_embeddings:
-        for layer, tensor in representations.items():
-            torch.save(
-                tensor,
-                f"{self.output_dir}/cache/embeddings_{layer}_batch{batch_idx}.pt",
-            )
-    if self.extract_attention_matrices:
-        for layer, matrices in self.attention_matrices_average_layers.items():
-            torch.save(
-                torch.save(matrices),
-                f"{self.output_dir}/cache/attention_matrices_{layer}_batch{batch_idx}.pt",
-            )
-        # if self.extract_cdr3_attention_matrices:
-        #     output["cdr3_attention_matrices"] = {
-        #         layer: matrix[i].detach().numpy().tolist()
-        #         for layer, matrix in self.cdr3_attention_matrices.items()
-        #     }

--- a/embedairr/base_embedder.py
+++ b/embedairr/base_embedder.py
@@ -15,7 +15,7 @@ class BaseEmbedder:
         self.context = args.context
         self.layers = list(map(int, args.layers.split()))
         self.cdr3_dict = self.load_cdr3(args.cdr3_path)
-        self.batch_size = 50  # TODO make this an argument
+        self.batch_size = args.batch_size  # TODO make this an argument
         self.max_length = 200  # TODO make this an argument
         if torch.cuda.is_available():
             self.device = torch.device("cuda")
@@ -27,7 +27,6 @@ class BaseEmbedder:
         for output_type in self.output_types:
             if "attention" in output_type:
                 self.return_contacts = True
-        self.gino = 1
         self.flatten = True
 
     def set_output_objects(self):
@@ -182,12 +181,8 @@ class BaseEmbedder:
     def get_cdr3_positions(self, label, context=0):
         """Get the start and end positions of the CDR3 sequence in the full sequence."""
         full_sequence = self.sequences[label]
-        # print('full_sequence', full_sequence)
-        # print('label', label)
-        # print(self.cdr3_dict[label])
         try:
             cdr3_sequence = self.cdr3_dict[label]
-            # print('yess')
         except KeyError:
             SystemExit(f"No cdr3 sequence found for {label}")
         # remove '-' from cdr3_sequence

--- a/embedairr/embedairr.py
+++ b/embedairr/embedairr.py
@@ -7,7 +7,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.insert(0, parent_dir)
 from embedairr.model_selecter import select_model
-
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"]="false"
 
 # Parsing command-line arguments for input and output file paths
 def parse_arguments():
@@ -75,7 +75,14 @@ def parse_arguments():
         nargs="+",
         help="Set the CDR3 attention matrix return types. Choose one or more from: 'False', 'all_heads', 'average_layer', 'average_all'. Requires --cdr3_path to be set. Default is 'False'.",
     )
-    # TODO add argument for batch_size
+    # arguemnt for batch_size
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=1024,
+        help="Batch size for loading sequences. Default is 1024.",
+    )
+
     # TODO add experiment name
     args = parser.parse_args()
     return args
@@ -83,8 +90,8 @@ def parse_arguments():
 
 if __name__ == "__main__":
     # Parse and store arguments
+
     args = parse_arguments()
-    layers = list(map(int, args.layers.strip().split()))
 
     # Check if output directory exists and creates it if it's missing
     if not os.path.exists(args.output_path):

--- a/embedairr/embedairr_debug.py
+++ b/embedairr/embedairr_debug.py
@@ -1,0 +1,253 @@
+import argparse
+import sys
+import os
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"]="false"
+#max split XLA 512
+# os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:1024"
+# Add the parent directory to the PYTHONPATH
+current_dir = os.getcwd()
+parent_dir = os.path.dirname("/doctorai/niccoloc/embedairr/embedairr/esm2_embedder.py")
+sys.path.insert(0, parent_dir)
+from embedairr.model_selecter import select_model
+from embedairr.model_selecter import select_model
+#import embedairr.model_selector
+
+
+# import torch
+
+# # Step 1: Create a list of four random tensors, each of shape [231, 231]
+# tensor_list = [torch.rand(231, 231) for _ in range(4)]
+
+# # Step 2: Stack the list of tensors along a new dimension
+# stacked_tensor = torch.stack(tensor_list, dim=0)
+
+# # Step 3: Print the shape to verify
+# print("Shape of each original tensor:", tensor_list[0].shape)  # Should be torch.Size([231, 231])
+# print("Shape of stacked tensor:", stacked_tensor.shape)         # Should be torch.Size([4
+
+
+
+
+print("PYTHONPATH:", sys.path)
+
+
+sys.argv = [
+    "embedairr.py",  # Script name
+    "--model_name", "ab2",
+    "--fasta_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_5k_antiberta2.fa",
+    # "--fasta_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_100k_antiberta2.fa",
+    "--output_path", "/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/",
+    "--cdr3_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_cdr3.csv",
+    "--extract_cdr3_attention_matrices", "average_layer",
+    "--extract_cdr3_embeddings", "unpooled",
+    "--layers", "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 ",
+    # "--extract_embeddings", "unpooled",
+    # "--extract_attention_matrices", "average_layer"
+]
+
+
+sys.argv = [
+    "embedairr.py",  # Script name
+    "--model_name", "esm2",
+    "--fasta_path","/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_100k_esm2.fa",
+    # "--fasta_path","/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_5k_esm2.fa",
+    "--output_path", "/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis2/",
+    "--layers", "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33",
+    # "--extract_embeddings", "unpooled",
+    "--extract_attention_matrices", "average_layer"
+]
+
+
+
+
+ 
+sys.argv = [
+    "embedairr.py",  # Script name
+    "--model_name", "esm2",
+    # "--fasta_path","/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_100k_esm2.fa",
+    "--fasta_path","/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_heavy_chain_100k.fa",
+    "--output_path", "/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis2/",
+    "--cdr3_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_cdr3.csv",
+    "--extract_cdr3_attention_matrices", "average_layer",
+    "--extract_cdr3_embeddings", "unpooled",
+    "--layers", "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33",
+    "--extract_embeddings", "false",
+    # "--extract_attention_matrices", "average_layer"
+]
+    
+
+
+
+# Parsing command-line arguments for input and output file paths
+def parse_arguments():
+    # """Parse command-line arguments for input and output file paths."""
+    parser = argparse.ArgumentParser(description="Input path")
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        required=True,
+        help="Model name. Example: esm2_t33_650M_UR50D",
+    )
+    parser.add_argument(
+        "--fasta_path", type=str, required=True, help="Fasta path + filename.fa"
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Directory for output files \n Will generate a subdirectory for outputs of each output_type.\n Will output multiple files if multiple layers are specified with '--layers'. Output file is a single tensor or a list of tensors when --pooling is False.",
+    )
+    parser.add_argument(
+        "--cdr3_path",
+        default=None,
+        type=str,
+        help="Path to the CDR3 CSV file. Only required when calculating CDR3 sequence embeddings.",
+    )
+    parser.add_argument(
+        "--context",
+        default=0,
+        type=int,
+        help="Number of amino acids to include before and after CDR3 sequence",
+    )
+    parser.add_argument(
+        "--layers",
+        type=str,
+        nargs="?",
+        default=["-1"],  # TODO: add option to return all layers
+        help="Representation layers to extract from the model. Default is the last layer. Example: argument '--layers -1 6' will output the last layer and the sixth layer.",
+    )
+    parser.add_argument(
+        "--extract_embeddings",
+        choices=["pooled", "unpooled", "false"],
+        default=["pooled"],
+        nargs="+",
+        help="Set the embedding return types. Choose one or more from: 'True', 'False', 'unpooled'. Default is 'True'.",
+    )
+    parser.add_argument(
+        "--extract_cdr3_embeddings",
+        choices=["pooled", "unpooled", "false"],
+        default=["pooled"],
+        nargs="+",
+        help="Set the CDR3 embedding return types. Choose one or more from: 'True', 'False', 'unpooled'. Requires --cdr3_path to be set. Default is 'True'.",
+    )
+    parser.add_argument(
+        "--extract_attention_matrices",
+        choices=["false", "all_heads", "average_layer", "average_all"],
+        default=["false"],
+        nargs="+",
+        help="Set the attention matrix return types. Choose one or more from: 'False', 'all_heads', 'average_layer', 'average_all'. Default is 'False'.",
+    )
+    parser.add_argument(
+        "--extract_cdr3_attention_matrices",
+        choices=["false", "all_heads", "average_layer", "average_all"],
+        default=["false"],
+        nargs="+",
+        help="Set the CDR3 attention matrix return types. Choose one or more from: 'False', 'all_heads', 'average_layer', 'average_all'. Requires --cdr3_path to be set. Default is 'False'.",
+    )
+    # arguemnt for batch_size
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=1024,
+        help="Batch size for loading sequences. Default is 1024.",
+    )
+    # TODO add experiment name
+    args = parser.parse_args()
+    return args
+
+# gino=1
+# import torch
+# x1 = torch.load  ("/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/ab2/attention_matrices_average_layers/tz_paired_chain_5k_antiberta2_ab2_attention_matrices_average_layers_layer_1.pt")
+# x1 = torch.load  ("/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/esm2/attention_matrices_average_layers/tz_paired_chain_5k_esm2_esm2_attention_matrices_average_layers_layer_1.pt")
+# x1 = torch.load  ("/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/esm2/attention_matrices_average_layers/tz_paired_chain_5k_esm2_esm2_attention_matrices_average_layers_layer_1.pt")
+
+
+# x1 = torch.load  ("/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/esm2/embeddings_unpooled/tz_paired_chain_5k_esm2_esm2_embeddings_unpooled_layer_1.pt")
+# x1 = torch.load  ("/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis2/ab2/embeddings_unpooled/tz_paired_chain_5k_antiberta2_ab2_embeddings_unpooled_layer_1.pt")
+# x1[0].shape
+
+# torch.stack(x1[0:3],dim=0).shape
+
+
+
+# torch.flatten(x1, start_dim =1).shape
+# x2 = x1.view(x1.size(0), -1).shape
+
+# x2 = x1.reshape(x1.size(0), -1)
+
+# torch.save(x2.to(torch.float16), "/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/esm2/attention_matrices_average_layers/tz_paired_chain_5k_esm2_esm2_attention_matrices_average_layers_layer_1_FLAT.pt")
+
+# Check the data type (precision) of the tensor
+
+# x3= torch.load  ("/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/esm2/attention_matrices_average_layers/tz_paired_chain_5k_esm2_esm2_attention_matrices_average_layers_layer_1_FLAT.pt")
+# torch.save(x2, "/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis3/ab2/attention_matrices_average_layers/tz_paired_chain_5k_antiberta2_ab2_attention_matrices_average_layers_layer_1_STACK.pt")
+
+
+# if __name__ == "__main__":
+    # Parse and store arguments
+#re import select_model
+
+
+
+
+
+args = parse_arguments()
+
+# Check if output directory exists and creates it if it's missing
+if not os.path.exists(args.output_path):
+    os.makedirs(args.output_path)
+
+embedder = select_model(args.model_name)
+
+embedder = embedder(args)
+
+print("Embedder initialized")
+
+embedder.run()
+
+print("All outputs saved.")
+
+if embedder.flatten and "unpooled" in embedder.output_types[1]:
+  print('ciao')
+
+
+
+sys.argv = [
+    "embedairr.py",  # Script name
+    "--model_name", "ab2",
+    # "--fasta_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_5k_antiberta2.fa",
+    # "--fasta_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_paired_chain_100k_antiberta2.fa",
+    "--fasta_path","/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_heavy_chain_100k.fa",
+    "--output_path", "/doctorai/userdata/airr_atlas/data/embeddings/levels_analysis2/",
+    "--cdr3_path", "/doctorai/userdata/airr_atlas/data/sequences/bcr/trastuzumab/tz_cdr3.csv",
+    "--extract_cdr3_attention_matrices", "average_layer",
+    "--extract_cdr3_embeddings", "unpooled",
+    "--layers", "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 ",
+    # "--extract_embeddings", "unpooled",
+    # "--extract_attention_matrices", "average_layer"
+]
+    
+
+del embedder
+args = parse_arguments()
+
+# Check if output directory exists and creates it if it's missing
+if not os.path.exists(args.output_path):
+  os.makedirs(args.output_path)
+
+embedder = select_model(args.model_name)
+
+embedder = embedder(args)
+
+print("Embedder initialized")
+
+embedder.run()
+
+print("All outputs saved.")
+
+
+
+# import torch
+
+# torch.stack(embedder.cdr3_context_extracted_unpooled[1][0:4],dim=0).flatten(start_dim=1)
+

--- a/embedairr/esm2_embedder.py
+++ b/embedairr/esm2_embedder.py
@@ -50,8 +50,6 @@ class ESM2Embedder(BaseEmbedder):
         print("Loading and batching input sequences...")
         # Creating a dataset from the input fasta file
         dataset = FastaBatchedDataset.from_file(self.fasta_path)
-        # Generating batch indices based on token count
-        print( batch_size) 
         batches = dataset.get_batch_indices(batch_size, extra_toks_per_seq=1)
         # DataLoader to iterate through batches efficiently
         data_loader = torch.utils.data.DataLoader(
@@ -79,19 +77,6 @@ class ESM2Embedder(BaseEmbedder):
             for layer in range(1, self.num_layers + 1)
         }
 
-    # def extract_attention_matrices_average_layer(
-    #     self, out, representations, batch_labels, batch_sequences
-    # ):
-    #     dict_attention_matrices_average_layers = {
-    #         layer: (
-    #             self.attention_matrices_average_layers[layer]
-    #             + [
-    #                 out["attentions"][i, layer - 1, :, 1:-1, 1:-1].mean(0).cpu()
-    #                 for i in range(len(batch_labels))
-    #             ]
-    #         )
-    #         for layer in range(1, self.num_layers + 1)
-    #     }
 
     def extract_attention_matrices_average_layer(
         self, out, representations, batch_labels, batch_sequences
@@ -106,26 +91,6 @@ class ESM2Embedder(BaseEmbedder):
             # Append the new batch to the existing list
             self.attention_matrices_average_layers[layer].extend(attentions_batch)
 
-
-
-
-        #instead of chanign all the code, get the dictioanry and stack the tensors
-        
-        # stacked_layers = []
-        # for layer, tensor_list in dict_attention_matrices_average_layers.items():
-        #     # Concatenate all tensors in the list along the first dimension (rows)
-        #     print(tensor_list[0].shape)
-        #     stacked_tensor = torch.stack(tensor_list, dim=0)
-        #     # Store the stacked tensor for the current layer
-        #     stacked_layers.append(stacked_tensor)
-        #     self.attention_matrices_average_layers[layer] = torch.cat(self.attention_matrices_average_layers[layer],stacked_layers, dim = 0 )
-        # if self.gino == 1:
-        #     print("ciao")
-        #     print(layer)
-        #     # print(tensor_list)
-        #     print(stacked_layers[1].shape)
-        #     print("AOAOAOOAOAOAOOA")
-        #     self.gino =0
 
     def extract_attention_matrices_average_all(
         self, out, representations, batch_labels, batch_sequences
@@ -197,7 +162,6 @@ class ESM2Embedder(BaseEmbedder):
                 outputs = self.model(
                     toks, repr_layers=self.layers, return_contacts=self.return_contacts
                 )
-                # outputs["attentions"].to( dtype=torch.float16)
                 # Extracting layer representations and moving them to CPU
                 representations = {
                     layer: t.to(device="cpu", dtype=torch.float16)

--- a/embedairr/test_import.py
+++ b/embedairr/test_import.py
@@ -1,0 +1,7 @@
+import sys
+
+print("PYTHONPATH:", sys.path)
+
+from embedairr.model_selecter import select_model
+
+print("Import successful")


### PR DESCRIPTION
antiberta2_embedder.py:
        - Attention matrices exported as float16 instead of float32
        - Added environment flag to disable  GPU VRAM pre-allocation
        - Changed batch_size
    esm2_embedder.py:
        - Attention matrices exported as float16 instead of float32
        - Added environment flag to disable  GPU VRAM pre-allocation
        - Changed batch_size
    base_embedder.py:
        - fixed cdr3_embedding extraction
        - Added an option to flatten tensors when saving (default = True)
general :
    - remove write_batch from antiberta2_embedder.py
    - add args.batch_size to base_embedder.py
    - Clear up comments in esm2_embedder.py
    - Merge changes to base_embedder.py when possible