### PR TITLE
chore: add CI, fix license metadata, document maintenance workflow

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - numpy
     - protobuf
     - alive-progress
+    - rjieba
 
 about:
   home: https://github.com/csi-greifflab/pepe-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          # biopython: used by the splitting tests.
-          # rjieba: required by AntiBERTa2's RoFormerTokenizer (see test_splitting.py).
-          pip install pytest biopython rjieba
+          # biopython is a test-only dependency (used by the splitting tests).
+          # rjieba is NOT installed here on purpose: it's a real package dependency
+          # (AntiBERTa2's RoFormerTokenizer needs it), so `pip install -e .` must
+          # provide it. If it doesn't, these tests should fail — that's the point.
+          pip install pytest biopython
       - name: Run integration tests (downloads esm2_t6_8M, ~30 MB)
         run: |
           python -m pytest -v \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest biopython
+          # biopython: used by the splitting tests.
+          # rjieba: required by AntiBERTa2's RoFormerTokenizer (see test_splitting.py).
+          pip install pytest biopython rjieba
       - name: Run integration tests (downloads esm2_t6_8M, ~30 MB)
         run: |
           python -m pytest -v \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+# Runs the test suite on every push and pull request, so problems are caught
+# BEFORE code is merged or published — not at release time. This is separate
+# from the publish-*.yml workflows, which build and upload packages.
+
+on:
+  push:
+    branches: [main, test]
+  pull_request:
+
+# If you push again before a run finishes, cancel the older run.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests (mocked, no model downloads)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+      - name: Run fast unit tests
+        run: |
+          python -m pytest -v \
+            src/tests/test_parse_arguments.py \
+            src/tests/test_device_logic.py \
+            src/tests/test_load_layers_default.py
+
+  integration:
+    name: Integration tests (downloads a small model)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest biopython
+      - name: Run integration tests (downloads esm2_t6_8M, ~30 MB)
+        run: |
+          python -m pytest -v \
+            src/tests/test_api_unittest.py \
+            src/tests/test_splitting.py

--- a/.gitignore
+++ b/.gitignore
@@ -140,11 +140,19 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv-*/
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Stray local clones of this repo (do not nest git repos inside the working tree)
+/pepe-cli/
+/pepe-cli-*/
+
+# Local-only planning notes (not published with the project for now)
+/ROADMAP.md
 
 # Spyder project settings
 .spyderproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to PEPE are recorded here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+given a version `MAJOR.MINOR.PATCH`, increment
+
+- **MAJOR** when you make an incompatible change (e.g. rename/remove a CLI flag,
+  change `embed()`'s signature, or change the output file format),
+- **MINOR** when you add functionality in a backward-compatible way,
+- **PATCH** when you make backward-compatible bug fixes.
+
+When you cut a release, move items from `Unreleased` into a new dated version
+section and bump `__version__` in `src/pepe/__init__.py` (the single source of
+truth that drives publishing).
+
+## [Unreleased]
+
+### Added
+- Continuous-integration workflow (`.github/workflows/test.yml`) that runs the
+  test suite on every push and pull request.
+- `CONTRIBUTING.md` with dev-environment setup, how to run tests, and the
+  release process.
+- This changelog.
+
+### Fixed
+- Corrected the PyPI license classifier from "GNU Affero General Public License
+  v3" to "MIT License" in `pyproject.toml` and `setup.py`, matching the actual
+  `LICENSE` file.
+
+### Removed
+- Stray nested clones of the repository (`pepe-cli/`, `pepe-cli-1/`) that were
+  sitting inside the working tree.
+
+## [1.2.1]
+
+### Fixed
+- TestPyPI publishing: resolved version-collision and packaging-metadata issues
+  on test-branch pushes.
+
+## [1.2.0]
+
+### Added
+- ESMC model support (`biohub/ESMC-*`), loaded via Biohub's `transformers` fork.
+
+### Changed
+- ESM-2 models are now loaded through HuggingFace `transformers` instead of
+  `fair-esm`.
+
+## [1.1.1]
+
+### Fixed
+- Removed a duplicate default on the `--device` argument.
+
+---
+
+*Versions prior to 1.1.1 predate this changelog; see the git history for details.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ truth that drives publishing).
 - `CONTRIBUTING.md` with dev-environment setup, how to run tests, and the
   release process.
 - This changelog.
+- `rjieba` as a runtime dependency, required by AntiBERTa2's `RoFormerTokenizer`.
+  Previously AntiBERTa2 models failed with an `ImportError` unless users
+  installed it manually; CI now guards against this regression.
 
 ### Fixed
 - Corrected the PyPI license classifier from "GNU Affero General Public License

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+PEPE (Pipeline for Easy Protein Embedding) is a CLI + Python library that extracts embeddings and attention matrices from protein sequences using pre-trained protein language models (ESM-1/2, ESMC, ProtT5, AntiBERTa2, and arbitrary HuggingFace / custom PyTorch models). Published to PyPI and Conda as `pepe-cli`; the import module is `pepe`.
+
+## Source layout
+
+The real package lives in `src/pepe/`. The repo root also contains untracked `pepe-cli/` and `pepe-cli-1/` directories that are stray full copies of the project — **ignore them; do all work under `src/`.**
+
+## Commands
+
+```sh
+# Editable install (needed before running CLI, library, or tests)
+pip install -e .
+
+# For ESM-1 models only (fair-esm, not covered by the base deps)
+pip install fair-esm
+
+# For ESMC models only (biohub/ESMC-*): Biohub's transformers fork
+pip install git+https://github.com/Biohub/transformers.git@main
+
+# Run the CLI
+pepe --model_name esm2_t6_8M_UR50D --fasta_path <file> --output_path <dir> --extract_embeddings mean_pooled
+
+# Run the test suite (unittest-style, but pytest-compatible). Run from repo ROOT —
+# tests reference relative paths like src/tests/test_files/.
+python -m pytest src/tests/
+python -m pytest src/tests/test_api_unittest.py            # single file
+python -m pytest src/tests/test_api_unittest.py::TestPepeAPI::test_embed_to_disk   # single test
+```
+
+Note: `src/tests/test_run.py` and `test_run.sh` are stale (they use removed args like `--batch_writing` and an old constructor signature); don't treat them as the test entry point.
+
+## Version / release flow
+
+`src/pepe/__init__.py` `__version__` is the **single source of truth** — `pyproject.toml` and `setup.py` both read metadata from it (`__version__`, `__package_name__`, etc.). Bumping that string is what drives publishing:
+
+- Push to `main` → `.github/workflows/publish-main-branch-trusted.yml` builds and publishes to PyPI. The version must **not** contain `-dev`/`-test`.
+- Push to `test` → publishes to TestPyPI.
+
+## Architecture
+
+Two entry points converge on the same engine:
+
+- **CLI**: `pepe.__main__:main` → `parse_arguments()` → `select_model(model_name)` → `Embedder(args).run()`.
+- **Library**: `pepe.embed(...)` in `api.py` packs kwargs into a `SimpleNamespace` (mimicking the argparse `args`) and calls the same `select_model` + `.run()` path. When no `output_path` is given it writes to a temp dir, disables streaming, and returns in-memory results.
+
+Both paths pass a single `args` object to every embedder constructor — so **CLI flags in `parse_arguments.py`, the `embed()` signature/`args_dict` in `api.py`, and attribute reads in `base_embedder.py` must stay in sync.**
+
+### Model dispatch — `model_selecter.py`
+
+`select_model(model_name)` is a factory that returns the embedder **class** by inspecting the name:
+- contains `esm2` → `ESM2Embedder`; `esm1` → `ESMEmbedder` (fair-esm)
+- looks like a local path / `.pt` / `.pth` / `custom:` prefix → `CustomEmbedder`
+- contains `/` (HuggingFace id) → loads `AutoConfig` and dispatches on `config.model_type` (t5→`T5Embedder`, roformer→`Antiberta2Embedder`, esm→`ESM2Embedder`, esmc→`ESMCEmbedder`).
+
+Heavy deps (torch, transformers, esm) are **lazily imported** inside functions/methods throughout, so `--help` and the CLI stay fast and optional backends (fair-esm, Biohub fork) only load when actually used. Preserve this pattern when adding models.
+
+### Embedder hierarchy
+
+`BaseEmbedder` (`embedders/base_embedder.py`) is the engine; subclasses only supply model/tokenizer loading and `_compute_outputs`:
+- `ESMEmbedder` (`esm_embedder.py`) — ESM-1 via fair-esm.
+- `HuggingfaceEmbedder` and subclasses `ESM2Embedder`, `ESMCEmbedder`, `T5Embedder`, `Antiberta2Embedder`, `GenericHuggingFaceEmbedder` (`huggingface_embedder.py`).
+- `CustomEmbedder` (`custom_embedder.py`) — local `.pt` models.
+
+`BaseEmbedder.run()` → `embed()` iterates the DataLoader, calls `_safe_compute` (which recursively **halves the batch and retries on CUDA OOM**), then routes each batch through the extraction methods selected by `--extract_embeddings`.
+
+### Output types
+
+`_set_output_objects()` defines one entry per output type — `per_token`, `mean_pooled`, `substring_pooled`, `attention_head`, `attention_layer`, `attention_model`, `logits` — each a dict of `{output_data, method (_extract_*), output_dir, shape}`. `extract_embeddings` picks which run. Adding an output type means adding both the dict entry and the matching `_extract_*` method. Files are saved as `.npy` under `<output_path>/<model_name>/<output_type>/`, plus a `*_idx.csv` mapping row index → sequence id. Note `logits` is only produced by ESM-2 (via `AutoModelForMaskedLM`); the generic HuggingFace path drops it.
+
+### Streaming I/O (default) vs in-memory
+
+`streaming_output=True` (default) preallocates `numpy.memmap` files (`preallocate_disk_space()` → `memmap_registry`) and streams batches to disk via `MultiIODispatcher` / `IOFlushWorker` threads (`utils.py`), with backpressure and a `global_checkpoint.json` for crash recovery/resume. This keeps memory flat for arbitrarily large datasets. With `streaming_output=False`, results accumulate in RAM and are written by `export_to_disk()`. `--discard_padding` is incompatible with streaming and silently disables it.
+
+### Batching & datasets
+
+`utils.py` holds the `Dataset` classes (`HuggingFaceDataset`, `ESMDataset`, `CustomDataset`, all extending `SequenceDictDataset`) and `TokenBudgetBatchSampler`. **`--batch_size` is a token budget (total tokens per batch), not a sequence count** — batch size is derived as `token_budget // padded_seq_len`.
+
+### Long-sequence splitting
+
+Models with hard length limits (ESM-2 ~1024, AntiBERTa2 256) are handled in `base_embedder.py`: `_check_max_input_length` / `_get_model_max_allowed` detect the limit, `_handle_sequence_splitting` chunks over-long sequences into overlapping pieces (`--split_long_sequences`, `--split_overlap`, `--force_split_length`), and `_reconstruct_chunks` stitches per-token/logits/mean-pooled outputs back together (in-memory mode only; under streaming, chunks are exported individually).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to PEPE
+
+Notes for maintaining and extending PEPE — written to be useful whether you're a
+first-time contributor or future-you coming back after six months.
+
+## Development setup
+
+```sh
+# Clone, then from the repo root:
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install -e .                 # editable install: code changes take effect immediately
+pip install pytest biopython     # test-only dependencies
+
+# Optional backends, only if you work on those models:
+pip install fair-esm                                             # ESM-1 models
+pip install git+https://github.com/Biohub/transformers.git@main  # ESMC models
+```
+
+## Running tests
+
+Always run from the **repository root** (tests use paths like
+`src/tests/test_files/`).
+
+```sh
+# Full suite
+python -m pytest src/tests/
+
+# Fast tests only — mocked, no model downloads (what CI gates every push on)
+python -m pytest src/tests/test_parse_arguments.py \
+                 src/tests/test_device_logic.py \
+                 src/tests/test_load_layers_default.py
+
+# A single test
+python -m pytest src/tests/test_api_unittest.py::TestPepeAPI::test_embed_to_disk
+```
+
+Some tests download a small model (`esm2_t6_8M_UR50D`, ~30 MB) on first run.
+ESMC tests skip themselves automatically if the Biohub fork isn't installed.
+
+**Rule of thumb:** every time you fix a bug, add a test that would have caught
+it. That is how the suite becomes a map of everything that has ever gone wrong.
+
+## Branching and pull requests
+
+- `main` is the release branch (publishes to **PyPI**).
+- `test` is the integration branch (publishes to **TestPyPI**) and is where
+  day-to-day work lands.
+- Do work on a short-lived branch off `test`, open a pull request into `test`,
+  and let CI go green before merging. Merge `test` into `main` when you're ready
+  to cut a public release.
+- Don't commit directly to `main` or `test`.
+
+## Making a release
+
+1. Decide the new version number using [SemVer](https://semver.org) (see
+   `CHANGELOG.md` for what MAJOR/MINOR/PATCH mean here).
+2. Update the `Unreleased` section of `CHANGELOG.md` into a new version section.
+3. Bump `__version__` in `src/pepe/__init__.py` — this single value drives all
+   packaging metadata (`pyproject.toml` and `setup.py` read from it) and
+   triggers the publish workflows. The version on `main` must **not** contain a
+   `-dev` or `-test` suffix.
+4. Merge to the appropriate branch. The `publish-*.yml` GitHub Actions build and
+   upload the package.
+5. Tag the release so results stay reproducible: `git tag v<version> && git push --tags`.
+
+## Adding support for a new model
+
+The architecture is documented in `CLAUDE.md`. In short:
+
+- `select_model()` in `src/pepe/model_selecter.py` maps a model name to an
+  embedder class — add your dispatch rule there.
+- Embedders subclass `BaseEmbedder` (`src/pepe/embedders/base_embedder.py`) and
+  typically only need to implement model/tokenizer loading and `_compute_outputs`.
+- Keep heavy imports (torch, transformers, esm) **lazy** — imported inside
+  functions/methods, not at module top level — so `--help` stays fast and
+  optional backends remain optional.
+- Adding a new output type means adding both an entry in `_set_output_objects()`
+  and the matching `_extract_*` method.
+
+## Deprecating things
+
+You have real users now. When you must change a CLI flag or a public API, keep
+the old behavior working with a warning for a release or two rather than
+removing it outright.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy",
     "protobuf",
     "alive_progress",
+    "rjieba",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sentencepiece
 numpy
 protobuf
 alive_progress
+rjieba

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: Linux",
         "Operating System :: macOS",
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "numpy",
         "protobuf",
         "alive_progress",
+        "rjieba",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Sets up long-term maintenance infrastructure for the project.

## Changes

- **CI on every push/PR** — `.github/workflows/test.yml` runs the test suite (unit tests across Python 3.9–3.11 + an integration job that downloads a small model), separate from the publish workflows. Catches regressions before merge/publish rather than at release time.
- **License metadata fixed** — corrected the PyPI classifier from "GNU Affero General Public License v3" to "MIT License" in `pyproject.toml` and `setup.py`, matching the actual `LICENSE` file and conda recipe.
- **`CHANGELOG.md`** — Keep a Changelog + SemVer, seeded from recent versions.
- **`CONTRIBUTING.md`** — dev-env setup, running tests, branching, and the release process.
- **`CLAUDE.md`** — architecture notes for contributors.
- **`.gitignore`** — ignore stray local clones and `.venv-*` dirs.
- **Removed** stray nested repo clones (`pepe-cli/`, `pepe-cli-1/`) that were sitting inside the working tree.

## Verification

- All 14 fast unit tests pass locally (`test_parse_arguments`, `test_device_logic`, `test_load_layers_default`).
- `test.yml` validated as well-formed YAML.
- License now consistently MIT across `LICENSE`, `pyproject.toml`, `setup.py`, and the conda recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)