### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/publish-main-branch-trusted.yml
+++ b/.github/workflows/publish-main-branch-trusted.yml
@@ -15,10 +15,10 @@ jobs:
       pull-requests: read
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     
@@ -140,7 +140,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}
@@ -173,10 +173,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-publish-main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: '3.10'

--- a/.github/workflows/publish-test-branch-trusted.yml
+++ b/.github/workflows/publish-test-branch-trusted.yml
@@ -16,10 +16,10 @@ jobs:
       test_version: ${{ steps.version_step.outputs.test_version }}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     
@@ -106,10 +106,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-publish-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -44,8 +44,8 @@ jobs:
     name: Integration tests (downloads a small model)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip


### PR DESCRIPTION
Follow-up to #8 (that PR merged before this commit was pushed, so it was left out).

GitHub Actions runners default to Node 24 as of 2026-06-16 and remove Node 20 entirely in fall 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This bumps every Node-based action across the test and publish workflows to its Node 24 major:

- `actions/checkout` v4 → v5
- `actions/setup-python` v4/v5 → v6
- `softprops/action-gh-release` v1 → v3
- `conda-incubator/setup-miniconda` v3 → v4

`pypa/gh-action-pypi-publish` is Docker-based and unaffected. The inputs these actions consume are unchanged across the bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)