### PR TITLE
Release 1.3.0 (test → main)

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - numpy
     - protobuf
     - alive-progress
+    - rjieba
 
 about:
   home: https://github.com/csi-greifflab/pepe-cli

--- a/.github/workflows/publish-main-branch-trusted.yml
+++ b/.github/workflows/publish-main-branch-trusted.yml
@@ -15,10 +15,10 @@ jobs:
       pull-requests: read
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     
@@ -140,7 +140,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}
@@ -173,10 +173,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-publish-main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: '3.10'

--- a/.github/workflows/publish-test-branch-trusted.yml
+++ b/.github/workflows/publish-test-branch-trusted.yml
@@ -37,8 +37,10 @@ jobs:
         CURRENT_VERSION=$(grep -m1 '__version__ = ' src/pepe/__init__.py | sed 's/__version__ = "\(.*\)"/\1/')
         PACKAGE_NAME=$(grep -m1 '__package_name__ = ' src/pepe/__init__.py | sed 's/__package_name__ = "\(.*\)"/\1/')
         MODULE_NAME=$(grep -m1 '__module_name__ = ' src/pepe/__init__.py | sed 's/__module_name__ = "\(.*\)"/\1/')
-        # Create test version by replacing -dev with .dev and adding timestamp
-        TEST_VERSION=$(echo $CURRENT_VERSION | sed -E "s/(-dev|\.dev[0-9]*)$/.dev${TIMESTAMP}/")
+        # Create a unique TestPyPI version by stripping any existing dev suffix,
+        # then appending .dev{timestamp} (TestPyPI rejects re-uploading the same version).
+        BASE_VERSION=$(echo "$CURRENT_VERSION" | sed -E 's/(-dev|\.dev[0-9]*)$//')
+        TEST_VERSION="${BASE_VERSION}.dev${TIMESTAMP}"
         
         # Output version for other jobs
         echo "test_version=$TEST_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-test-branch-trusted.yml
+++ b/.github/workflows/publish-test-branch-trusted.yml
@@ -16,10 +16,10 @@ jobs:
       test_version: ${{ steps.version_step.outputs.test_version }}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     
@@ -106,10 +106,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-publish-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          # biopython: used by the splitting tests.
-          # rjieba: required by AntiBERTa2's RoFormerTokenizer (see test_splitting.py).
-          pip install pytest biopython rjieba
+          # biopython is a test-only dependency (used by the splitting tests).
+          # rjieba is NOT installed here on purpose: it's a real package dependency
+          # (AntiBERTa2's RoFormerTokenizer needs it), so `pip install -e .` must
+          # provide it. If it doesn't, these tests should fail — that's the point.
+          pip install pytest biopython
       - name: Run integration tests (downloads esm2_t6_8M, ~30 MB)
         run: |
           python -m pytest -v \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest biopython
+          # biopython: used by the splitting tests.
+          # rjieba: required by AntiBERTa2's RoFormerTokenizer (see test_splitting.py).
+          pip install pytest biopython rjieba
       - name: Run integration tests (downloads esm2_t6_8M, ~30 MB)
         run: |
           python -m pytest -v \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -44,8 +44,8 @@ jobs:
     name: Integration tests (downloads a small model)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+# Runs the test suite on every push and pull request, so problems are caught
+# BEFORE code is merged or published — not at release time. This is separate
+# from the publish-*.yml workflows, which build and upload packages.
+
+on:
+  push:
+    branches: [main, test]
+  pull_request:
+
+# If you push again before a run finishes, cancel the older run.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests (mocked, no model downloads)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+      - name: Run fast unit tests
+        run: |
+          python -m pytest -v \
+            src/tests/test_parse_arguments.py \
+            src/tests/test_device_logic.py \
+            src/tests/test_load_layers_default.py
+
+  integration:
+    name: Integration tests (downloads a small model)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest biopython
+      - name: Run integration tests (downloads esm2_t6_8M, ~30 MB)
+        run: |
+          python -m pytest -v \
+            src/tests/test_api_unittest.py \
+            src/tests/test_splitting.py

--- a/.gitignore
+++ b/.gitignore
@@ -140,11 +140,19 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv-*/
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Stray local clones of this repo (do not nest git repos inside the working tree)
+/pepe-cli/
+/pepe-cli-*/
+
+# Local-only planning notes (not published with the project for now)
+/ROADMAP.md
 
 # Spyder project settings
 .spyderproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to PEPE are recorded here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+given a version `MAJOR.MINOR.PATCH`, increment
+
+- **MAJOR** when you make an incompatible change (e.g. rename/remove a CLI flag,
+  change `embed()`'s signature, or change the output file format),
+- **MINOR** when you add functionality in a backward-compatible way,
+- **PATCH** when you make backward-compatible bug fixes.
+
+When you cut a release, move items from `Unreleased` into a new dated version
+section and bump `__version__` in `src/pepe/__init__.py` (the single source of
+truth that drives publishing).
+
+## [Unreleased]
+
+### Added
+- Continuous-integration workflow (`.github/workflows/test.yml`) that runs the
+  test suite on every push and pull request.
+- `CONTRIBUTING.md` with dev-environment setup, how to run tests, and the
+  release process.
+- This changelog.
+
+### Fixed
+- Corrected the PyPI license classifier from "GNU Affero General Public License
+  v3" to "MIT License" in `pyproject.toml` and `setup.py`, matching the actual
+  `LICENSE` file.
+
+### Removed
+- Stray nested clones of the repository (`pepe-cli/`, `pepe-cli-1/`) that were
+  sitting inside the working tree.
+
+## [1.2.1]
+
+### Fixed
+- TestPyPI publishing: resolved version-collision and packaging-metadata issues
+  on test-branch pushes.
+
+## [1.2.0]
+
+### Added
+- ESMC model support (`biohub/ESMC-*`), loaded via Biohub's `transformers` fork.
+
+### Changed
+- ESM-2 models are now loaded through HuggingFace `transformers` instead of
+  `fair-esm`.
+
+## [1.1.1]
+
+### Fixed
+- Removed a duplicate default on the `--device` argument.
+
+---
+
+*Versions prior to 1.1.1 predate this changelog; see the git history for details.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ truth that drives publishing).
 - `CONTRIBUTING.md` with dev-environment setup, how to run tests, and the
   release process.
 - This changelog.
+- `rjieba` as a runtime dependency, required by AntiBERTa2's `RoFormerTokenizer`.
+  Previously AntiBERTa2 models failed with an `ImportError` unless users
+  installed it manually; CI now guards against this regression.
 
 ### Fixed
 - Corrected the PyPI license classifier from "GNU Affero General Public License

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ truth that drives publishing).
 ## [Unreleased]
 
 ### Added
+- Broader model compatibility: BERT-like and other unrecognized HuggingFace
+  architectures now fall back to the generic `AutoModel`-based embedder instead
+  of raising, so standard protein encoders such as ProtBert, AntiBERTy and
+  IgBert work from a repo id with no code changes.
 - Continuous-integration workflow (`.github/workflows/test.yml`) that runs the
   test suite on every push and pull request.
 - `CONTRIBUTING.md` with dev-environment setup, how to run tests, and the
@@ -26,6 +30,18 @@ truth that drives publishing).
 - `rjieba` as a runtime dependency, required by AntiBERTa2's `RoFormerTokenizer`.
   Previously AntiBERTa2 models failed with an `ImportError` unless users
   installed it manually; CI now guards against this regression.
+
+### Changed
+- Model dispatch (`model_selecter.py`) now inspects a HuggingFace repo's config
+  (`AutoConfig.model_type`) before matching on its name. A fine-tune whose repo
+  slug contains "esm2" but whose architecture is something else is no longer
+  mis-routed. Bare ESM weight names (e.g. `esm2_t6_8M_UR50D`) and local
+  checkpoint paths keep their existing fast, no-download handling.
+- Bumped all Node-based GitHub Actions to their Node 24 majors across the test
+  and publish workflows (`actions/checkout` v4→v5, `actions/setup-python`
+  v4/v5→v6, `softprops/action-gh-release` v1→v3, `conda-incubator/setup-miniconda`
+  v3→v4), ahead of GitHub removing the Node 20 runtime in fall 2026.
+  `pypa/gh-action-pypi-publish` is Docker-based and unaffected.
 
 ### Fixed
 - Corrected the PyPI license classifier from "GNU Affero General Public License

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ truth that drives publishing).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-07
+
 ### Added
 - Broader model compatibility: BERT-like and other unrecognized HuggingFace
   architectures now fall back to the generic `AutoModel`-based embedder instead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+PEPE (Pipeline for Easy Protein Embedding) is a CLI + Python library that extracts embeddings and attention matrices from protein sequences using pre-trained protein language models (ESM-1/2, ESMC, ProtT5, AntiBERTa2, and arbitrary HuggingFace / custom PyTorch models). Published to PyPI and Conda as `pepe-cli`; the import module is `pepe`.
+
+## Source layout
+
+The real package lives in `src/pepe/`. The repo root also contains untracked `pepe-cli/` and `pepe-cli-1/` directories that are stray full copies of the project — **ignore them; do all work under `src/`.**
+
+## Commands
+
+```sh
+# Editable install (needed before running CLI, library, or tests)
+pip install -e .
+
+# For ESM-1 models only (fair-esm, not covered by the base deps)
+pip install fair-esm
+
+# For ESMC models only (biohub/ESMC-*): Biohub's transformers fork
+pip install git+https://github.com/Biohub/transformers.git@main
+
+# Run the CLI
+pepe --model_name esm2_t6_8M_UR50D --fasta_path <file> --output_path <dir> --extract_embeddings mean_pooled
+
+# Run the test suite (unittest-style, but pytest-compatible). Run from repo ROOT —
+# tests reference relative paths like src/tests/test_files/.
+python -m pytest src/tests/
+python -m pytest src/tests/test_api_unittest.py            # single file
+python -m pytest src/tests/test_api_unittest.py::TestPepeAPI::test_embed_to_disk   # single test
+```
+
+Note: `src/tests/test_run.py` and `test_run.sh` are stale (they use removed args like `--batch_writing` and an old constructor signature); don't treat them as the test entry point.
+
+## Version / release flow
+
+`src/pepe/__init__.py` `__version__` is the **single source of truth** — `pyproject.toml` and `setup.py` both read metadata from it (`__version__`, `__package_name__`, etc.). Bumping that string is what drives publishing:
+
+- Push to `main` → `.github/workflows/publish-main-branch-trusted.yml` builds and publishes to PyPI. The version must **not** contain `-dev`/`-test`.
+- Push to `test` → publishes to TestPyPI.
+
+## Architecture
+
+Two entry points converge on the same engine:
+
+- **CLI**: `pepe.__main__:main` → `parse_arguments()` → `select_model(model_name)` → `Embedder(args).run()`.
+- **Library**: `pepe.embed(...)` in `api.py` packs kwargs into a `SimpleNamespace` (mimicking the argparse `args`) and calls the same `select_model` + `.run()` path. When no `output_path` is given it writes to a temp dir, disables streaming, and returns in-memory results.
+
+Both paths pass a single `args` object to every embedder constructor — so **CLI flags in `parse_arguments.py`, the `embed()` signature/`args_dict` in `api.py`, and attribute reads in `base_embedder.py` must stay in sync.**
+
+### Model dispatch — `model_selecter.py`
+
+`select_model(model_name)` is a factory that returns the embedder **class** by inspecting the name:
+- contains `esm2` → `ESM2Embedder`; `esm1` → `ESMEmbedder` (fair-esm)
+- looks like a local path / `.pt` / `.pth` / `custom:` prefix → `CustomEmbedder`
+- contains `/` (HuggingFace id) → loads `AutoConfig` and dispatches on `config.model_type` (t5→`T5Embedder`, roformer→`Antiberta2Embedder`, esm→`ESM2Embedder`, esmc→`ESMCEmbedder`).
+
+Heavy deps (torch, transformers, esm) are **lazily imported** inside functions/methods throughout, so `--help` and the CLI stay fast and optional backends (fair-esm, Biohub fork) only load when actually used. Preserve this pattern when adding models.
+
+### Embedder hierarchy
+
+`BaseEmbedder` (`embedders/base_embedder.py`) is the engine; subclasses only supply model/tokenizer loading and `_compute_outputs`:
+- `ESMEmbedder` (`esm_embedder.py`) — ESM-1 via fair-esm.
+- `HuggingfaceEmbedder` and subclasses `ESM2Embedder`, `ESMCEmbedder`, `T5Embedder`, `Antiberta2Embedder`, `GenericHuggingFaceEmbedder` (`huggingface_embedder.py`).
+- `CustomEmbedder` (`custom_embedder.py`) — local `.pt` models.
+
+`BaseEmbedder.run()` → `embed()` iterates the DataLoader, calls `_safe_compute` (which recursively **halves the batch and retries on CUDA OOM**), then routes each batch through the extraction methods selected by `--extract_embeddings`.
+
+### Output types
+
+`_set_output_objects()` defines one entry per output type — `per_token`, `mean_pooled`, `substring_pooled`, `attention_head`, `attention_layer`, `attention_model`, `logits` — each a dict of `{output_data, method (_extract_*), output_dir, shape}`. `extract_embeddings` picks which run. Adding an output type means adding both the dict entry and the matching `_extract_*` method. Files are saved as `.npy` under `<output_path>/<model_name>/<output_type>/`, plus a `*_idx.csv` mapping row index → sequence id. Note `logits` is only produced by ESM-2 (via `AutoModelForMaskedLM`); the generic HuggingFace path drops it.
+
+### Streaming I/O (default) vs in-memory
+
+`streaming_output=True` (default) preallocates `numpy.memmap` files (`preallocate_disk_space()` → `memmap_registry`) and streams batches to disk via `MultiIODispatcher` / `IOFlushWorker` threads (`utils.py`), with backpressure and a `global_checkpoint.json` for crash recovery/resume. This keeps memory flat for arbitrarily large datasets. With `streaming_output=False`, results accumulate in RAM and are written by `export_to_disk()`. `--discard_padding` is incompatible with streaming and silently disables it.
+
+### Batching & datasets
+
+`utils.py` holds the `Dataset` classes (`HuggingFaceDataset`, `ESMDataset`, `CustomDataset`, all extending `SequenceDictDataset`) and `TokenBudgetBatchSampler`. **`--batch_size` is a token budget (total tokens per batch), not a sequence count** — batch size is derived as `token_budget // padded_seq_len`.
+
+### Long-sequence splitting
+
+Models with hard length limits (ESM-2 ~1024, AntiBERTa2 256) are handled in `base_embedder.py`: `_check_max_input_length` / `_get_model_max_allowed` detect the limit, `_handle_sequence_splitting` chunks over-long sequences into overlapping pieces (`--split_long_sequences`, `--split_overlap`, `--force_split_length`), and `_reconstruct_chunks` stitches per-token/logits/mean-pooled outputs back together (in-memory mode only; under streaming, chunks are exported individually).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to PEPE
+
+Notes for maintaining and extending PEPE — written to be useful whether you're a
+first-time contributor or future-you coming back after six months.
+
+## Development setup
+
+```sh
+# Clone, then from the repo root:
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install -e .                 # editable install: code changes take effect immediately
+pip install pytest biopython     # test-only dependencies
+
+# Optional backends, only if you work on those models:
+pip install fair-esm                                             # ESM-1 models
+pip install git+https://github.com/Biohub/transformers.git@main  # ESMC models
+```
+
+## Running tests
+
+Always run from the **repository root** (tests use paths like
+`src/tests/test_files/`).
+
+```sh
+# Full suite
+python -m pytest src/tests/
+
+# Fast tests only — mocked, no model downloads (what CI gates every push on)
+python -m pytest src/tests/test_parse_arguments.py \
+                 src/tests/test_device_logic.py \
+                 src/tests/test_load_layers_default.py
+
+# A single test
+python -m pytest src/tests/test_api_unittest.py::TestPepeAPI::test_embed_to_disk
+```
+
+Some tests download a small model (`esm2_t6_8M_UR50D`, ~30 MB) on first run.
+ESMC tests skip themselves automatically if the Biohub fork isn't installed.
+
+**Rule of thumb:** every time you fix a bug, add a test that would have caught
+it. That is how the suite becomes a map of everything that has ever gone wrong.
+
+## Branching and pull requests
+
+- `main` is the release branch (publishes to **PyPI**).
+- `test` is the integration branch (publishes to **TestPyPI**) and is where
+  day-to-day work lands.
+- Do work on a short-lived branch off `test`, open a pull request into `test`,
+  and let CI go green before merging. Merge `test` into `main` when you're ready
+  to cut a public release.
+- Don't commit directly to `main` or `test`.
+
+## Making a release
+
+1. Decide the new version number using [SemVer](https://semver.org) (see
+   `CHANGELOG.md` for what MAJOR/MINOR/PATCH mean here).
+2. Update the `Unreleased` section of `CHANGELOG.md` into a new version section.
+3. Bump `__version__` in `src/pepe/__init__.py` — this single value drives all
+   packaging metadata (`pyproject.toml` and `setup.py` read from it) and
+   triggers the publish workflows. The version on `main` must **not** contain a
+   `-dev` or `-test` suffix.
+4. Merge to the appropriate branch. The `publish-*.yml` GitHub Actions build and
+   upload the package.
+5. Tag the release so results stay reproducible: `git tag v<version> && git push --tags`.
+
+## Adding support for a new model
+
+The architecture is documented in `CLAUDE.md`. In short:
+
+- `select_model()` in `src/pepe/model_selecter.py` maps a model name to an
+  embedder class — add your dispatch rule there.
+- Embedders subclass `BaseEmbedder` (`src/pepe/embedders/base_embedder.py`) and
+  typically only need to implement model/tokenizer loading and `_compute_outputs`.
+- Keep heavy imports (torch, transformers, esm) **lazy** — imported inside
+  functions/methods, not at module top level — so `--help` stays fast and
+  optional backends remain optional.
+- Adding a new output type means adding both an entry in `_set_output_objects()`
+  and the matching `_extract_*` method.
+
+## Deprecating things
+
+You have real users now. When you must change a CLI flag or a public API, keep
+the old behavior working with a warning for a release or two rather than
+removing it outright.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ PEPE (Pipeline for Easy Protein Embedding) is a tool for extracting embeddings a
     cd pepe-cli
     pip install .
     ```
+    For ESMC models (e.g. `biohub/ESMC-300M`), install the optional Biohub transformers fork. This does not affect ESM1 (`fair-esm`) support:
+    ```sh
+    pip install pepe-cli[esmc]
+    ```
 2. Run the embedding script:\
     Extract mean pooled embeddings from protein amino acid sequences in FASTA file:
     ```sh
@@ -188,6 +192,10 @@ results = pepe.embed(
     - RoFormer models
         - alchemab/antiberta2-cssp
         - alchemab/antiberta2
+    - ESMC models (requires `pip install pepe-cli[esmc]`)
+        - biohub/ESMC-300M
+        - biohub/ESMC-600M
+        - biohub/ESMC-6B
     - Custom Hugging Face models
         - Any compatible model from Hugging Face Hub: `username/model-name`
         - Private models with authentication
@@ -202,6 +210,7 @@ results = pepe.embed(
 ### Required Arguments
 - **`--model_name`** (str): Name of model or link to model. Choose from [List of supported models](../README.md#list-of-supported-models) or use custom models:
   - ESM models: `esm2_t33_650M_UR50D`
+  - ESMC models: `biohub/ESMC-300M` (requires `pip install pepe-cli[esmc]`)
   - Hugging Face models: `username/model-name`
   - Custom PyTorch models: `/path/to/model.pt` or `/path/to/model_directory/`
   - Local HF models: `/path/to/local_hf_directory/`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ PEPE (Pipeline for Easy Protein Embedding) is a tool for extracting embeddings a
 
 ## Quick start
 
-1. Install PEPE \
+1. Install PEPE
+
     From PyPI:    
     ```sh
     pip install pepe-cli
@@ -25,11 +26,13 @@ PEPE (Pipeline for Easy Protein Embedding) is a tool for extracting embeddings a
     cd pepe-cli
     pip install .
     ```
-    For ESMC models (e.g. `biohub/ESMC-300M`), install Biohub's transformers fork separately (PyPI does not allow git dependencies in package metadata; this does not affect ESM1 `fair-esm` support):
+
+2. *(Optional)* For ESMC models (e.g. `biohub/ESMC-300M`), install Biohub's transformers fork:
     ```sh
     pip install git+https://github.com/Biohub/transformers.git@main
     ```
-2. Run the embedding script:\
+
+3. Extract embeddings:\
     Extract mean pooled embeddings from protein amino acid sequences in FASTA file:
     ```sh
     pepe --experiment_name <optional_string> --fasta_path <file_path> --output_path <directory> --model_name <model_name>
@@ -39,7 +42,7 @@ PEPE (Pipeline for Easy Protein Embedding) is a tool for extracting embeddings a
 
 PEPE can also be used as a Python library. This allows for programmatic access to protein embeddings without using the command-line interface.
 
-1. Install PEPE (see [Quick start with CLI](#quick-start-with-cli) for details).
+1. Install PEPE (see above for details).
 2. Use the `pepe.embed()` function in your script:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ PEPE (Pipeline for Easy Protein Embedding) is a tool for extracting embeddings a
     cd pepe-cli
     pip install .
     ```
-    For ESMC models (e.g. `biohub/ESMC-300M`), install the optional Biohub transformers fork. This does not affect ESM1 (`fair-esm`) support:
+    For ESMC models (e.g. `biohub/ESMC-300M`), install Biohub's transformers fork separately (PyPI does not allow git dependencies in package metadata; this does not affect ESM1 `fair-esm` support):
     ```sh
-    pip install pepe-cli[esmc]
+    pip install git+https://github.com/Biohub/transformers.git@main
     ```
 2. Run the embedding script:\
     Extract mean pooled embeddings from protein amino acid sequences in FASTA file:
@@ -192,7 +192,7 @@ results = pepe.embed(
     - RoFormer models
         - alchemab/antiberta2-cssp
         - alchemab/antiberta2
-    - ESMC models (requires `pip install pepe-cli[esmc]`)
+    - ESMC models (requires Biohub transformers fork; see install instructions above)
         - biohub/ESMC-300M
         - biohub/ESMC-600M
         - biohub/ESMC-6B
@@ -210,7 +210,7 @@ results = pepe.embed(
 ### Required Arguments
 - **`--model_name`** (str): Name of model or link to model. Choose from [List of supported models](../README.md#list-of-supported-models) or use custom models:
   - ESM models: `esm2_t33_650M_UR50D`
-  - ESMC models: `biohub/ESMC-300M` (requires `pip install pepe-cli[esmc]`)
+  - ESMC models: `biohub/ESMC-300M` (requires Biohub transformers fork; see Quick start)
   - Hugging Face models: `username/model-name`
   - Custom PyTorch models: `/path/to/model.pt` or `/path/to/model_directory/`
   - Local HF models: `/path/to/local_hf_directory/`

--- a/examples/model_selection.md
+++ b/examples/model_selection.md
@@ -20,9 +20,9 @@ pepe \
 ```
 
 ### ESMC models
-ESMC (ESM Cambrian) is a distinct architecture from ESM2. It requires the Biohub transformers fork, which coexists with ESM1's `fair-esm` package:
+ESMC (ESM Cambrian) is a distinct architecture from ESM2. It requires Biohub's transformers fork, which coexists with ESM1's `fair-esm` package:
 ```sh
-pip install pepe-cli[esmc]
+pip install git+https://github.com/Biohub/transformers.git@main
 pepe \
     --experiment_name "esmc_test" \
     --model_name "biohub/ESMC-300M" \

--- a/examples/model_selection.md
+++ b/examples/model_selection.md
@@ -10,13 +10,27 @@ pepe \
 --output_path "src/tests/test_files/test_output"
 ```
 ## Models hosted on Huggingface
-The user can also choose from any PLM with the same input and output formats as the supported models hosted on    Huggingface Hub:
+The user can also choose from PLMs hosted on Huggingface Hub by passing the repository path as `--model_name`:
 ```sh
 pepe \
     --experiment_name "test" \
     --model_name "alchemab/antiberta2-cssp" \ # pass the remote path to a Huggingface model
     --fasta_path "src/tests/test_files/test.fasta" \
     --output_path "src/tests/test_files/test_output"
+```
+
+### ESMC models
+ESMC (ESM Cambrian) is a distinct architecture from ESM2. It requires the Biohub transformers fork, which coexists with ESM1's `fair-esm` package:
+```sh
+pip install pepe-cli[esmc]
+pepe \
+    --experiment_name "esmc_test" \
+    --model_name "biohub/ESMC-300M" \
+    --fasta_path "src/tests/test_files/test.fasta" \
+    --output_path "src/tests/test_files/test_output" \
+    --extract_embeddings mean_pooled \
+    --device cpu \
+    --layers -1
 ```
 
 ## Custom models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy",
     "protobuf",
     "alive_progress",
+    "rjieba",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,6 @@ dependencies = [
     "alive_progress",
 ]
 
-[project.optional-dependencies]
-esmc = [
-    "transformers @ git+https://github.com/Biohub/transformers.git@main",
-    "accelerate>=0.26.0",
-]
-
 [project.urls]
 Homepage = "https://github.com/csi-greifflab/pepe-cli"
 "Bug Reports" = "https://github.com/csi-greifflab/pepe-cli/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ dependencies = [
     "alive_progress",
 ]
 
+[project.optional-dependencies]
+esmc = [
+    "transformers @ git+https://github.com/Biohub/transformers.git@main",
+    "accelerate>=0.26.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/csi-greifflab/pepe-cli"
 "Bug Reports" = "https://github.com/csi-greifflab/pepe-cli/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sentencepiece
 numpy
 protobuf
 alive_progress
+rjieba

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: Linux",
         "Operating System :: macOS",
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,12 @@ setup(
         "protobuf",
         "alive_progress",
     ],
+    extras_require={
+        "esmc": [
+            "transformers @ git+https://github.com/Biohub/transformers.git@main",
+            "accelerate>=0.26.0",
+        ],
+    },
     entry_points={
         "console_scripts": [
             f"pepe = {__module_name__}.__main__:main",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "numpy",
         "protobuf",
         "alive_progress",
+        "rjieba",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,6 @@ setup(
         "protobuf",
         "alive_progress",
     ],
-    extras_require={
-        "esmc": [
-            "transformers @ git+https://github.com/Biohub/transformers.git@main",
-            "accelerate>=0.26.0",
-        ],
-    },
     entry_points={
         "console_scripts": [
             f"pepe = {__module_name__}.__main__:main",

--- a/src/pepe/__init__.py
+++ b/src/pepe/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     pass
 
 # Package metadata - single source of truth
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __package_name__ = "pepe-cli"
 __module_name__ = "pepe"
 __author__ = "Jahn Zhong"

--- a/src/pepe/__init__.py
+++ b/src/pepe/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     pass
 
 # Package metadata - single source of truth
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 __package_name__ = "pepe-cli"
 __module_name__ = "pepe"
 __author__ = "Jahn Zhong"

--- a/src/pepe/__init__.py
+++ b/src/pepe/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     pass
 
 # Package metadata - single source of truth
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 __package_name__ = "pepe-cli"
 __module_name__ = "pepe"
 __author__ = "Jahn Zhong"

--- a/src/pepe/__init__.py
+++ b/src/pepe/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     pass
 
 # Package metadata - single source of truth
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __package_name__ = "pepe-cli"
 __module_name__ = "pepe"
 __author__ = "Jahn Zhong"

--- a/src/pepe/embedders/custom_embedder.py
+++ b/src/pepe/embedders/custom_embedder.py
@@ -288,9 +288,10 @@ class CustomEmbedder(BaseEmbedder):
 
     def _load_layers(self, layers):
         """Process layer specification."""
+        if layers is None:
+            return list(range(1, self.num_layers + 1))
         if not layers:
-            layers = list(range(1, self.num_layers + 1))
-            return layers
+            layers = [-1]
 
         # Validate layer indices
         assert all(

--- a/src/pepe/embedders/esm_embedder.py
+++ b/src/pepe/embedders/esm_embedder.py
@@ -102,9 +102,10 @@ class ESMEmbedder(BaseEmbedder):
         return special_token_ids
 
     def _load_layers(self, layers):
+        if layers is None:
+            return list(range(1, self.model.num_layers + 1))  # type: ignore
         if not layers:
-            layers = list(range(1, self.model.num_layers + 1))  # type: ignore
-            return layers
+            layers = [-1]
         # Checking if the specified representation layers are valid
         assert all(
             -(self.model.num_layers + 1) <= i <= self.model.num_layers for i in layers  # type: ignore

--- a/src/pepe/embedders/huggingface_embedder.py
+++ b/src/pepe/embedders/huggingface_embedder.py
@@ -53,20 +53,13 @@ class HuggingfaceEmbedder(BaseEmbedder):
 
     def _load_layers(self, layers):
         """Check if the specified representation layers are valid."""
+        num_layers = self.num_layers  # type: ignore
+        if layers is None:
+            return list(range(1, num_layers + 1))
         if not layers:
-            layers = list(range(1, self.model.config.num_hidden_layers + 1))  # type: ignore
-            return layers
-        assert all(
-            -(self.model.config.num_hidden_layers + 1)  # type: ignore
-            <= i
-            <= self.model.config.num_hidden_layers  # type: ignore
-            for i in layers
-        )
-        layers = [
-            (i + self.model.config.num_hidden_layers + 1)  # type: ignore
-            % (self.model.config.num_hidden_layers + 1)  # type: ignore
-            for i in layers
-        ]
+            layers = [-1]
+        assert all(-(num_layers + 1) <= i <= num_layers for i in layers)
+        layers = [(i + num_layers + 1) % (num_layers + 1) for i in layers]
         return layers
 
     def _load_data(self, sequences, substring_dict, bracket_type):
@@ -118,14 +111,18 @@ class HuggingfaceEmbedder(BaseEmbedder):
         else:
             attention_matrices = None
         if return_embeddings:
-            representations = {
-                layer: outputs.hidden_states[layer]
-                .to(
-                    self._precision_to_dtype(self.precision, "torch"),
-                )
-                .cpu()
-                for layer in self.layers  # type: ignore
-            }
+            dtype = self._precision_to_dtype(self.precision, "torch")
+            hidden_states = outputs.hidden_states
+            if isinstance(hidden_states, torch.Tensor):
+                representations = {
+                    layer: hidden_states[layer].to(dtype).cpu()
+                    for layer in self.layers  # type: ignore
+                }
+            else:
+                representations = {
+                    layer: hidden_states[layer].to(dtype).cpu()
+                    for layer in self.layers  # type: ignore
+                }
             torch.cuda.empty_cache()
         else:
             representations = None
@@ -413,6 +410,118 @@ class ESM2Embedder(HuggingfaceEmbedder):
             representations = None
 
         return logits, representations, attention_matrices
+
+
+def _get_config_attr(config, *names, default=None):
+    for name in names:
+        if hasattr(config, name):
+            return getattr(config, name)
+    return default
+
+
+class ESMCEmbedder(HuggingfaceEmbedder):
+    """ESMC embedder using Biohub transformers fork (model_type esmc)."""
+
+    def __init__(self, args):
+        BaseEmbedder.__init__(self, args)
+        self.sequences = pepe.utils.fasta_to_dict(args.fasta_path)
+        self.num_sequences = len(self.sequences)
+        (
+            self.model,
+            self.tokenizer,
+            self.num_heads,
+            self.num_layers,
+            self.embedding_size,
+        ) = self._initialize_model(self.model_link)
+        self.valid_tokens = self._get_valid_tokens()
+        self.bracket_type = pepe.utils.get_bracket_type(self.tokenizer)
+        self._check_max_input_length()
+        pepe.utils.check_input_tokens(
+            self.valid_tokens,
+            self.sequences,
+            self.model_name,
+            split_long_sequences=self.split_long_sequences,
+        )
+        self.special_tokens = torch.tensor(
+            self.tokenizer.all_special_ids, device=self.device, dtype=torch.int8
+        )
+        self.layers = self._load_layers(self.layers)
+        self.data_loader, self.max_input_length = self._load_data(
+            self.sequences, self.substring_dict, self.bracket_type
+        )
+        self._set_output_objects()
+
+    def _get_valid_tokens(self):
+        return {tok for tok in self.tokenizer.get_vocab().keys() if len(tok) == 1}
+
+    def _load_data(self, sequences, substring_dict, bracket_type):
+        dataset = pepe.utils.HuggingFaceDataset(
+            sequences,
+            substring_dict,
+            self.context,
+            bracket_type,
+            self.tokenizer,
+            self.max_input_length,
+            add_special_tokens=not self.disable_special_tokens,
+            gapped_sequences=False,
+        )
+        dataset.pad_token_id = self.tokenizer.pad_token_id
+        logger.info("Batching sequences...")
+        batch_sampler = pepe.utils.TokenBudgetBatchSampler(
+            dataset=dataset, token_budget=self.batch_size
+        )
+        data_loader = torch.utils.data.DataLoader(
+            dataset, batch_sampler=batch_sampler, collate_fn=dataset.safe_collate
+        )
+        max_length = dataset.get_max_encoded_length()
+        logger.info("Finished tokenizing and batching sequences")
+        return data_loader, max_length
+
+    def _initialize_model(self, model_link):
+        if torch.cuda.is_available() and self.device.type == "cuda":
+            device = torch.device("cuda")
+            logger.info("Transferred model to GPU")
+        else:
+            device = torch.device("cpu")
+            logger.info("No GPU available, using CPU")
+
+        (
+            T5EncoderModel,
+            T5Tokenizer,
+            RoFormerTokenizer,
+            RoFormerModel,
+            RoFormerSinusoidalPositionalEmbedding,
+            AutoModel,
+            AutoTokenizer,
+            AutoModelForCausalLM,
+            AutoModelForMaskedLM,
+        ) = _import_transformers()
+
+        logger.info(f"Loading ESMC model from HuggingFace: {model_link}")
+        tokenizer = AutoTokenizer.from_pretrained(model_link)
+        model_kwargs = {}
+        if self.return_contacts:
+            model_kwargs["attn_implementation"] = "eager"
+
+        if self.return_logits:
+            model = AutoModelForMaskedLM.from_pretrained(
+                model_link, **model_kwargs
+            ).to(device)
+        else:
+            model = AutoModel.from_pretrained(model_link, **model_kwargs).to(device)
+        model.eval()
+
+        config = model.config
+        num_heads = _get_config_attr(
+            config, "num_attention_heads", "n_heads", "num_heads"
+        )
+        num_layers = _get_config_attr(
+            config, "num_hidden_layers", "n_layers", "num_layers"
+        )
+        embedding_size = _get_config_attr(
+            config, "hidden_size", "d_model", "embed_dim"
+        )
+        return model, tokenizer, num_heads, num_layers, embedding_size
 
 
 class GenericHuggingFaceEmbedder(HuggingfaceEmbedder):

--- a/src/pepe/embedders/huggingface_embedder.py
+++ b/src/pepe/embedders/huggingface_embedder.py
@@ -15,6 +15,7 @@ def _import_transformers():
             RoFormerSinusoidalPositionalEmbedding,
         )
         from transformers import AutoModel, AutoTokenizer, AutoModelForCausalLM
+        from transformers import AutoModelForMaskedLM
 
         return (
             T5EncoderModel,
@@ -25,6 +26,7 @@ def _import_transformers():
             AutoModel,
             AutoTokenizer,
             AutoModelForCausalLM,
+            AutoModelForMaskedLM,
         )
     except ImportError as e:
         logger.error(f"Failed to import transformers: {e}")
@@ -182,6 +184,7 @@ class Antiberta2Embedder(HuggingfaceEmbedder):
             AutoModel,
             AutoTokenizer,
             AutoModelForCausalLM,
+            AutoModelForMaskedLM,
         ) = _import_transformers()
 
         tokenizer = RoFormerTokenizer.from_pretrained(model_link, use_fast=True)
@@ -246,6 +249,7 @@ class T5Embedder(HuggingfaceEmbedder):
             AutoModel,
             AutoTokenizer,
             AutoModelForCausalLM,
+            AutoModelForMaskedLM,
         ) = _import_transformers()
 
         tokenizer = T5Tokenizer.from_pretrained(model_link, use_fast=True)
@@ -255,6 +259,160 @@ class T5Embedder(HuggingfaceEmbedder):
         num_layers = model.config.num_layers
         embedding_size = model.config.hidden_size
         return model, tokenizer, num_heads, num_layers, embedding_size
+
+
+def _resolve_esm2_model_link(model_name):
+    if "/" in model_name:
+        return model_name
+    return f"facebook/{model_name}"
+
+
+class ESM2Embedder(HuggingfaceEmbedder):
+    """ESM-2 embedder using HuggingFace transformers instead of fair-esm."""
+
+    def __init__(self, args):
+        BaseEmbedder.__init__(self, args)
+        self.sequences = pepe.utils.fasta_to_dict(args.fasta_path)
+        self.num_sequences = len(self.sequences)
+        (
+            self.model,
+            self.tokenizer,
+            self.num_heads,
+            self.num_layers,
+            self.embedding_size,
+        ) = self._initialize_model(self.model_name)
+        self.valid_tokens = self._get_valid_tokens()
+        self.bracket_type = pepe.utils.get_bracket_type(self.tokenizer)
+        self._check_max_input_length()
+        pepe.utils.check_input_tokens(
+            self.valid_tokens,
+            self.sequences,
+            self.model_name,
+            split_long_sequences=self.split_long_sequences,
+        )
+        self.special_tokens = torch.tensor(
+            self.tokenizer.all_special_ids, device=self.device, dtype=torch.int8
+        )
+        self.layers = self._load_layers(self.layers)
+        self.data_loader, self.max_input_length = self._load_data(
+            self.sequences, self.substring_dict, self.bracket_type
+        )
+        self._set_output_objects()
+
+    def _get_valid_tokens(self):
+        return {tok for tok in self.tokenizer.get_vocab().keys() if len(tok) == 1}
+
+    def _load_data(self, sequences, substring_dict, bracket_type):
+        dataset = pepe.utils.HuggingFaceDataset(
+            sequences,
+            substring_dict,
+            self.context,
+            bracket_type,
+            self.tokenizer,
+            self.max_input_length,
+            add_special_tokens=not self.disable_special_tokens,
+        )
+        dataset.pad_token_id = self.tokenizer.pad_token_id
+        logger.info("Batching sequences...")
+        batch_sampler = pepe.utils.TokenBudgetBatchSampler(
+            dataset=dataset, token_budget=self.batch_size
+        )
+        data_loader = torch.utils.data.DataLoader(
+            dataset, batch_sampler=batch_sampler, collate_fn=dataset.safe_collate
+        )
+        max_length = dataset.get_max_encoded_length()
+        logger.info("Finished tokenizing and batching sequences")
+        return data_loader, max_length
+
+    def _initialize_model(self, model_name):
+        model_link = _resolve_esm2_model_link(model_name)
+        if torch.cuda.is_available() and self.device.type == "cuda":
+            device = torch.device("cuda")
+            logger.info("Transferred model to GPU")
+        else:
+            device = torch.device("cpu")
+            logger.info("No GPU available, using CPU")
+
+        (
+            T5EncoderModel,
+            T5Tokenizer,
+            RoFormerTokenizer,
+            RoFormerModel,
+            RoFormerSinusoidalPositionalEmbedding,
+            AutoModel,
+            AutoTokenizer,
+            AutoModelForCausalLM,
+            AutoModelForMaskedLM,
+        ) = _import_transformers()
+
+        logger.info(f"Loading ESM-2 model from HuggingFace: {model_link}")
+        tokenizer = AutoTokenizer.from_pretrained(model_link)
+        model_kwargs = {}
+        if self.return_contacts:
+            model_kwargs["attn_implementation"] = "eager"
+
+        if self.return_logits:
+            model = AutoModelForMaskedLM.from_pretrained(
+                model_link, **model_kwargs
+            ).to(device)
+        else:
+            model = AutoModel.from_pretrained(model_link, **model_kwargs).to(device)
+        model.eval()
+
+        config = model.config
+        num_heads = config.num_attention_heads
+        num_layers = config.num_hidden_layers
+        embedding_size = config.hidden_size
+        return model, tokenizer, num_heads, num_layers, embedding_size
+
+    def _compute_outputs(
+        self,
+        model,
+        toks,
+        attention_mask,
+        return_embeddings,
+        return_contacts,
+        return_logits=False,
+    ):
+        outputs = model(
+            input_ids=toks,
+            attention_mask=attention_mask,
+            output_hidden_states=return_embeddings,
+            output_attentions=return_contacts,
+        )
+        if return_logits:
+            logits = (
+                outputs.logits
+                .to(dtype=self._precision_to_dtype(self.precision, "torch"))
+                .permute(2, 0, 1)
+                .cpu()
+            )
+            torch.cuda.empty_cache()
+        else:
+            logits = None
+
+        if return_contacts:
+            attention_matrices = (
+                torch.stack(outputs.attentions)  # type: ignore
+                .to(self._precision_to_dtype(self.precision, "torch"))  # type: ignore
+                .cpu()
+            )
+            torch.cuda.empty_cache()
+        else:
+            attention_matrices = None
+
+        if return_embeddings:
+            representations = {
+                layer: outputs.hidden_states[layer]
+                .to(self._precision_to_dtype(self.precision, "torch"))
+                .cpu()
+                for layer in self.layers  # type: ignore
+            }
+            torch.cuda.empty_cache()
+        else:
+            representations = None
+
+        return logits, representations, attention_matrices
 
 
 class GenericHuggingFaceEmbedder(HuggingfaceEmbedder):
@@ -320,6 +478,7 @@ class GenericHuggingFaceEmbedder(HuggingfaceEmbedder):
             AutoModel,
             AutoTokenizer,
             AutoModelForCausalLM,
+            AutoModelForMaskedLM,
         ) = _import_transformers()
 
         # For models that commonly require custom code, use trust_remote_code=True immediately

--- a/src/pepe/model_selecter.py
+++ b/src/pepe/model_selecter.py
@@ -31,18 +31,18 @@ def _get_huggingface_embedders():
     return T5Embedder, Antiberta2Embedder
 
 
+def _get_generic_hf_embedder():
+    """Lazy import of the generic AutoModel-based HuggingFace fallback embedder."""
+    from pepe.embedders.huggingface_embedder import GenericHuggingFaceEmbedder
+
+    return GenericHuggingFaceEmbedder
+
+
 def select_model(model_name):
-    if "esm2" in model_name.lower():
-        return _get_esm2_embedder()
-    elif "esm1" in model_name.lower():
-        return _get_esm_embedder()
-    # elif "antiberta2" in model_name.lower() and model_name.startswith("alchemab"):
-    #    T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
-    #    return Antiberta2Embedder
-    # elif "t5" in model_name.lower() and model_name.startswith("Rostlab"):
-    #    T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
-    #    return T5Embedder
-    elif (
+    # 1. Local checkpoints / directories take precedence over any name heuristic,
+    #    so a local file or folder is never mistaken for a HuggingFace repo id or a
+    #    bare weight name (e.g. a directory called "my_esm2_run/").
+    if (
         model_name.endswith(".pt")
         or model_name.endswith(".pth")
         or model_name.startswith("custom:")
@@ -52,53 +52,83 @@ def select_model(model_name):
         )
     ):
         return CustomEmbedder
-    elif "/" in model_name:
-        # Assume it's a Hugging Face model (username/model-name format)
-        # Try to determine the architecture automatically
-        try:
-            from transformers import AutoConfig
 
-            config = AutoConfig.from_pretrained(model_name)
-            model_type = config.model_type.lower()
+    # 2. Anything shaped like a HuggingFace repo id (username/model-name) is
+    #    dispatched by inspecting its config, not its name. This is the primary
+    #    signal: a fine-tune whose slug says "esm2" but is really a BERT no longer
+    #    gets mis-routed.
+    if "/" in model_name:
+        return _select_hf_model(model_name)
 
-            if model_type in ["t5", "mt5"]:
-                T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
-                return T5Embedder
-            elif model_type in ["roformer"]:
-                T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
-                return Antiberta2Embedder
-            elif model_type in ["esm"]:
-                return _get_esm2_embedder()
-            elif model_type in ["esmc"]:
-                return _get_esmc_embedder()
-            elif model_type in ["bert"]:
-                # For BERT-like models, we could potentially use a generic embedder
-                # but for now, suggest using CustomEmbedder or creating a specific one
-                raise ValueError(
-                    f"BERT-like models are not yet directly supported. Consider using a PyTorch version of the model with CustomEmbedder."
-                )
-            else:
-                # For other architectures, you might want to add more specific embedders
-                # or use a generic HuggingfaceEmbedder
-                raise ValueError(
-                    f"Model architecture '{model_type}' not yet supported for custom Hugging Face models"
-                )
-        except Exception as e:
-            error_msg = str(e)
-            if "esmc" in model_name.lower() or "esmc" in error_msg.lower():
-                raise ValueError(
-                    f"ESMC models require Biohub's transformers fork (ESM1 fair-esm is unaffected). "
-                    f"Install with: pip install git+https://github.com/Biohub/transformers.git@main"
-                ) from e
-            if "Unrecognized model" in error_msg or "model_type" in error_msg:
-                raise ValueError(
-                    f"Model {model_name} appears to be a Keras/TensorFlow model or has an unsupported architecture. PEPE currently supports PyTorch models only. Consider using a PyTorch version or converting the model."
-                ) from e
-            raise ValueError(
-                f"Could not determine model architecture for {model_name}: {e}"
-            ) from e
-    else:
-        raise ValueError(f"Model {model_name} not supported")
+    # 3. Bare weight names (no slash) are fair-esm / facebook ESM weight sets, which
+    #    have no downloadable config to inspect. Match on the name for these only.
+    if "esm2" in model_name.lower():
+        return _get_esm2_embedder()
+    if "esm1" in model_name.lower():
+        return _get_esm_embedder()
+
+    raise ValueError(
+        f"Model {model_name} not supported. Pass a HuggingFace repo id "
+        f"(username/model-name), a local .pt/.pth path or directory, or a bare ESM "
+        f"weight name (e.g. esm2_t6_8M_UR50D)."
+    )
+
+
+def _select_hf_model(model_name):
+    """Dispatch a HuggingFace repo id to an embedder by inspecting its config.
+
+    Known architectures get their specialized embedder; everything else (BERT-like
+    encoders and any architecture without a dedicated embedder) falls back to the
+    generic AutoModel-based ``GenericHuggingFaceEmbedder``. The forward pass is
+    architecture-agnostic, so standard encoders such as ProtBert, AntiBERTy and
+    IgBert work through the fallback with no engine changes.
+    """
+    try:
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(model_name)
+    except Exception as e:
+        _raise_hf_config_error(model_name, e)
+
+    model_type = (getattr(config, "model_type", "") or "").lower()
+
+    if model_type in ["t5", "mt5"]:
+        T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
+        return T5Embedder
+    if model_type in ["roformer"]:
+        T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
+        return Antiberta2Embedder
+    if model_type in ["esm"]:
+        return _get_esm2_embedder()
+    if model_type in ["esmc"]:
+        return _get_esmc_embedder()
+
+    # Fallback: BERT-like and any other architecture route to the generic embedder
+    # instead of raising.
+    import logging
+
+    logging.getLogger("src.model_selecter").info(
+        f"No specialized embedder for architecture '{model_type or 'unknown'}'; "
+        f"using the generic HuggingFace embedder for {model_name}."
+    )
+    return _get_generic_hf_embedder()
+
+
+def _raise_hf_config_error(model_name, error):
+    """Translate an AutoConfig load failure into an actionable ValueError."""
+    error_msg = str(error)
+    if "esmc" in model_name.lower() or "esmc" in error_msg.lower():
+        raise ValueError(
+            f"ESMC models require Biohub's transformers fork (ESM1 fair-esm is unaffected). "
+            f"Install with: pip install git+https://github.com/Biohub/transformers.git@main"
+        ) from error
+    if "Unrecognized model" in error_msg or "model_type" in error_msg:
+        raise ValueError(
+            f"Model {model_name} appears to be a Keras/TensorFlow model or has an unsupported architecture. PEPE currently supports PyTorch models only. Consider using a PyTorch version or converting the model."
+        ) from error
+    raise ValueError(
+        f"Could not load model config for {model_name}: {error}"
+    ) from error
 
 
 supported_models = [

--- a/src/pepe/model_selecter.py
+++ b/src/pepe/model_selecter.py
@@ -10,6 +10,13 @@ def _get_esm_embedder():
     return ESMEmbedder
 
 
+def _get_esm2_embedder():
+    """Lazy import of ESM-2 embedder (HuggingFace transformers)."""
+    from pepe.embedders.huggingface_embedder import ESM2Embedder
+
+    return ESM2Embedder
+
+
 def _get_huggingface_embedders():
     """Lazy import of HuggingFace embedders to avoid loading heavy dependencies."""
     from pepe.embedders.huggingface_embedder import T5Embedder, Antiberta2Embedder
@@ -19,7 +26,7 @@ def _get_huggingface_embedders():
 
 def select_model(model_name):
     if "esm2" in model_name.lower():
-        return _get_esm_embedder()
+        return _get_esm2_embedder()
     elif "esm1" in model_name.lower():
         return _get_esm_embedder()
     # elif "antiberta2" in model_name.lower() and model_name.startswith("alchemab"):
@@ -53,6 +60,8 @@ def select_model(model_name):
             elif model_type in ["roformer"]:
                 T5Embedder, Antiberta2Embedder = _get_huggingface_embedders()
                 return Antiberta2Embedder
+            elif model_type in ["esm"]:
+                return _get_esm2_embedder()
             elif model_type in ["bert"]:
                 # For BERT-like models, we could potentially use a generic embedder
                 # but for now, suggest using CustomEmbedder or creating a specific one

--- a/src/pepe/model_selecter.py
+++ b/src/pepe/model_selecter.py
@@ -87,8 +87,8 @@ def select_model(model_name):
             error_msg = str(e)
             if "esmc" in model_name.lower() or "esmc" in error_msg.lower():
                 raise ValueError(
-                    f"ESMC models require the Biohub transformers fork (ESM1 fair-esm is unaffected). "
-                    f"Install with: pip install pepe-cli[esmc]"
+                    f"ESMC models require Biohub's transformers fork (ESM1 fair-esm is unaffected). "
+                    f"Install with: pip install git+https://github.com/Biohub/transformers.git@main"
                 ) from e
             if "Unrecognized model" in error_msg or "model_type" in error_msg:
                 raise ValueError(
@@ -128,7 +128,7 @@ supported_models = [
     "Rostlab/ProstT5",
     "alchemab/antiberta2-cssp",
     "alchemab/antiberta2",
-    # ESMC models (requires pip install pepe-cli[esmc])
+    # ESMC models (requires Biohub transformers fork; see README)
     "biohub/ESMC-300M",
     "biohub/ESMC-600M",
     "biohub/ESMC-6B",

--- a/src/pepe/model_selecter.py
+++ b/src/pepe/model_selecter.py
@@ -17,6 +17,13 @@ def _get_esm2_embedder():
     return ESM2Embedder
 
 
+def _get_esmc_embedder():
+    """Lazy import of ESMC embedder (Biohub transformers fork)."""
+    from pepe.embedders.huggingface_embedder import ESMCEmbedder
+
+    return ESMCEmbedder
+
+
 def _get_huggingface_embedders():
     """Lazy import of HuggingFace embedders to avoid loading heavy dependencies."""
     from pepe.embedders.huggingface_embedder import T5Embedder, Antiberta2Embedder
@@ -62,6 +69,8 @@ def select_model(model_name):
                 return Antiberta2Embedder
             elif model_type in ["esm"]:
                 return _get_esm2_embedder()
+            elif model_type in ["esmc"]:
+                return _get_esmc_embedder()
             elif model_type in ["bert"]:
                 # For BERT-like models, we could potentially use a generic embedder
                 # but for now, suggest using CustomEmbedder or creating a specific one
@@ -75,16 +84,19 @@ def select_model(model_name):
                     f"Model architecture '{model_type}' not yet supported for custom Hugging Face models"
                 )
         except Exception as e:
-            # Check if it's a Keras/TensorFlow model
             error_msg = str(e)
+            if "esmc" in model_name.lower() or "esmc" in error_msg.lower():
+                raise ValueError(
+                    f"ESMC models require the Biohub transformers fork (ESM1 fair-esm is unaffected). "
+                    f"Install with: pip install pepe-cli[esmc]"
+                ) from e
             if "Unrecognized model" in error_msg or "model_type" in error_msg:
                 raise ValueError(
-                    f"Model {model_name} appears to be a Keras/TensorFlow model or has an unsupported architecture. EmbedAIRR currently supports PyTorch models only. Consider using a PyTorch version or converting the model."
-                )
-            else:
-                raise ValueError(
-                    f"Could not determine model architecture for {model_name}: {e}"
-                )
+                    f"Model {model_name} appears to be a Keras/TensorFlow model or has an unsupported architecture. PEPE currently supports PyTorch models only. Consider using a PyTorch version or converting the model."
+                ) from e
+            raise ValueError(
+                f"Could not determine model architecture for {model_name}: {e}"
+            ) from e
     else:
         raise ValueError(f"Model {model_name} not supported")
 
@@ -116,6 +128,10 @@ supported_models = [
     "Rostlab/ProstT5",
     "alchemab/antiberta2-cssp",
     "alchemab/antiberta2",
+    # ESMC models (requires pip install pepe-cli[esmc])
+    "biohub/ESMC-300M",
+    "biohub/ESMC-600M",
+    "biohub/ESMC-6B",
     # Custom models examples:
     # - PyTorch models: "/path/to/model.pt", "/path/to/model_directory/", "custom:/path/to/model.pt"
     # - Hugging Face models: "username/model-name", "./local_hf_model"

--- a/src/pepe/utils.py
+++ b/src/pepe/utils.py
@@ -147,13 +147,17 @@ class HuggingFaceDataset(SequenceDictDataset):
         tokenizer,
         max_length,
         add_special_tokens=True,
+        gapped_sequences=True,
     ):
         super().__init__(sequences, substring_dict, context, bracket_type)
-        
+        self.gapped_sequences = gapped_sequences
+
         self.encoded_data = self._encode_sequences(
-            self.data, tokenizer, max_length, add_special_tokens, gapped_sequences = True
+            self.data, tokenizer, max_length, add_special_tokens, gapped_sequences
         )  # (label, seq, toks, attention_mask)
-        self.pad_token_id = tokenizer.pad_token_type_id
+        self.pad_token_id = (
+            getattr(tokenizer, "pad_token_type_id", None) or tokenizer.pad_token_id
+        )
         if self.substring_dict:
             logger.info("Tokenizing substrings...")
             self.encoded_substring_data = self._encode_sequences(
@@ -161,7 +165,7 @@ class HuggingFaceDataset(SequenceDictDataset):
                 tokenizer,
                 "max_length",
                 add_special_tokens=False,
-                gapped_sequences=True
+                gapped_sequences=gapped_sequences,
             )  # (label, seq, toks, attention_mask)
             self.substring_masks = self._get_substring_masks()
 

--- a/src/tests/test_device_logic.py
+++ b/src/tests/test_device_logic.py
@@ -99,7 +99,11 @@ class TestDeviceLogic(unittest.TestCase):
         source = inspect.getsource(ESMEmbedder._initialize_model)
         self.assertIn('self.device.type == "cuda"', source)
         
-        from pepe.embedders.huggingface_embedder import Antiberta2Embedder
+        from pepe.embedders.huggingface_embedder import Antiberta2Embedder, ESM2Embedder
+        import inspect
+        source = inspect.getsource(ESM2Embedder._initialize_model)
+        self.assertIn('self.device.type == "cuda"', source)
+        
         source = inspect.getsource(Antiberta2Embedder._initialize_model)
         self.assertIn('self.device.type == "cuda"', source)
 

--- a/src/tests/test_esmc.py
+++ b/src/tests/test_esmc.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from pepe.model_selecter import select_model
+
+
+class TestESMCModelSelection(unittest.TestCase):
+    def test_select_esmc_returns_esmc_embedder(self):
+        mock_config = MagicMock()
+        mock_config.model_type = "esmc"
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=mock_config):
+            embedder_cls = select_model("biohub/ESMC-300M")
+
+        from pepe.embedders.huggingface_embedder import ESMCEmbedder
+
+        self.assertIs(embedder_cls, ESMCEmbedder)
+
+    def test_select_esmc_missing_fork_error(self):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=ValueError("Unrecognized model_type esmc"),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                select_model("biohub/ESMC-300M")
+
+        self.assertIn("pepe-cli[esmc]", str(ctx.exception))
+
+
+@unittest.skipUnless(
+    os.environ.get("ESMC_TEST") == "1",
+    "Set ESMC_TEST=1 to run ESMC integration test (requires pepe-cli[esmc])",
+)
+class TestESMCIntegration(unittest.TestCase):
+    def test_esmc_mean_pooled(self):
+        import pepe
+
+        sequences = {
+            "seq1": "MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHGKKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLLSHCLLVTLAAHLPAEFTPAVHASLDKFLASVSTVLTSKYR",
+        }
+        results = pepe.embed(
+            model_name="biohub/ESMC-300M",
+            sequences=sequences,
+            extract_embeddings=["mean_pooled"],
+            layers=[[-1]],
+            device="cpu",
+        )
+
+        self.assertIn("mean_pooled", results)
+        layer_outputs = results["mean_pooled"]
+        layer_key = next(iter(layer_outputs))
+        self.assertEqual(len(layer_outputs[layer_key]), 1)
+        self.assertEqual(layer_outputs[layer_key][0].shape[0], 960)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_esmc.py
+++ b/src/tests/test_esmc.py
@@ -28,12 +28,12 @@ class TestESMCModelSelection(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 select_model("biohub/ESMC-300M")
 
-        self.assertIn("pepe-cli[esmc]", str(ctx.exception))
+        self.assertIn("Biohub/transformers", str(ctx.exception))
 
 
 @unittest.skipUnless(
     os.environ.get("ESMC_TEST") == "1",
-    "Set ESMC_TEST=1 to run ESMC integration test (requires pepe-cli[esmc])",
+    "Set ESMC_TEST=1 to run ESMC integration test (requires Biohub transformers fork)",
 )
 class TestESMCIntegration(unittest.TestCase):
     def test_esmc_mean_pooled(self):

--- a/src/tests/test_esmc_modes.py
+++ b/src/tests/test_esmc_modes.py
@@ -1,0 +1,93 @@
+"""Smoke tests for ESMC embedding modes. Run with ESMC_TEST=1."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath("src"))
+
+import pepe
+
+
+@unittest.skipUnless(
+    os.environ.get("ESMC_TEST") == "1",
+    "Set ESMC_TEST=1 to run ESMC mode tests",
+)
+class TestESMCEmbeddingModes(unittest.TestCase):
+    MODEL = "biohub/ESMC-300M"
+    EMBED_DIM = 960
+    NUM_LAYERS = 30
+    NUM_HEADS = 15
+
+    def _embed(self, **kwargs):
+        defaults = {
+            "model_name": self.MODEL,
+            "device": "cpu",
+            "layers": [[-1]],
+            "streaming_output": False,
+        }
+        defaults.update(kwargs)
+        return pepe.embed(**defaults)
+
+    def test_per_token(self):
+        sequences = {"seq1": "MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHGKKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLLSHCLLVTLAAHLPAEFTPAVHASLDKFLASVSTVLTSKYR"}
+        results = self._embed(
+            sequences=sequences,
+            extract_embeddings=["per_token"],
+        )
+        self.assertIn("per_token", results)
+        layer = self.NUM_LAYERS
+        self.assertIn(layer, results["per_token"])
+        arr = results["per_token"][layer][0]
+        self.assertEqual(arr.ndim, 2)
+        self.assertEqual(arr.shape[1], self.EMBED_DIM)
+        self.assertGreater(arr.shape[0], 0)
+
+    def test_substring_pooled(self):
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+        fasta = os.path.join(repo_root, "src/tests/test_files/test.fasta")
+        substring = os.path.join(repo_root, "src/tests/test_files/test_substring.csv")
+        results = self._embed(
+            fasta_path=fasta,
+            substring_path=substring,
+            extract_embeddings=["substring_pooled"],
+        )
+        self.assertIn("substring_pooled", results)
+        layer = self.NUM_LAYERS
+        self.assertIn(layer, results["substring_pooled"])
+        outputs = results["substring_pooled"][layer]
+        self.assertEqual(len(outputs), 10)
+        for arr in outputs:
+            self.assertEqual(arr.shape, (self.EMBED_DIM,))
+
+    def test_attention_head(self):
+        sequences = {"seq1": "ACDEFGHIKLMNPQRSTVWY"}
+        results = self._embed(
+            sequences=sequences,
+            extract_embeddings=["attention_head"],
+        )
+        self.assertIn("attention_head", results)
+        layer = self.NUM_LAYERS
+        self.assertIn(layer, results["attention_head"])
+        head_outputs = results["attention_head"][layer]
+        self.assertEqual(len(head_outputs), self.NUM_HEADS)
+        for head in range(self.NUM_HEADS):
+            arr = head_outputs[head][0]
+            self.assertEqual(arr.ndim, 2)
+            self.assertEqual(arr.shape[0], arr.shape[1])
+
+    def test_attention_layer(self):
+        sequences = {"seq1": "ACDEFGHIKLMNPQRSTVWY"}
+        results = self._embed(
+            sequences=sequences,
+            extract_embeddings=["attention_layer"],
+        )
+        self.assertIn("attention_layer", results)
+        layer = self.NUM_LAYERS
+        self.assertIn(layer, results["attention_layer"])
+        arr = results["attention_layer"][layer][0]
+        self.assertEqual(arr.ndim, 2)
+        self.assertEqual(arr.shape[0], arr.shape[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_load_layers_default.py
+++ b/src/tests/test_load_layers_default.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from pepe.embedders.huggingface_embedder import HuggingfaceEmbedder
+
+
+class _StubEmbedder(HuggingfaceEmbedder):
+    def __init__(self, num_layers=30):
+        self.num_layers = num_layers
+
+
+class TestLoadLayersDefault(unittest.TestCase):
+    def test_none_returns_all_layers(self):
+        embedder = _StubEmbedder(num_layers=6)
+        self.assertEqual(embedder._load_layers(None), [1, 2, 3, 4, 5, 6])
+
+    def test_empty_returns_last_layer(self):
+        embedder = _StubEmbedder(num_layers=30)
+        self.assertEqual(embedder._load_layers([]), [30])
+
+    def test_omitted_normalized_to_last_layer(self):
+        embedder = _StubEmbedder(num_layers=30)
+        self.assertEqual(embedder._load_layers([-1]), [30])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_model_selection.py
+++ b/src/tests/test_model_selection.py
@@ -1,0 +1,104 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from pepe.model_selecter import select_model
+
+
+def _config(model_type):
+    cfg = MagicMock()
+    cfg.model_type = model_type
+    return cfg
+
+
+class TestHuggingFaceDispatch(unittest.TestCase):
+    """Config-first dispatch for HuggingFace repo ids (username/model-name)."""
+
+    def _select_with_type(self, model_type, model_name="someuser/model-x"):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            return_value=_config(model_type),
+        ):
+            return select_model(model_name)
+
+    def test_bert_routes_to_generic_embedder(self):
+        from pepe.embedders.huggingface_embedder import GenericHuggingFaceEmbedder
+
+        self.assertIs(self._select_with_type("bert"), GenericHuggingFaceEmbedder)
+
+    def test_unknown_architecture_routes_to_generic_embedder(self):
+        from pepe.embedders.huggingface_embedder import GenericHuggingFaceEmbedder
+
+        self.assertIs(
+            self._select_with_type("some_new_arch"), GenericHuggingFaceEmbedder
+        )
+
+    def test_esm_config_routes_to_esm2_embedder(self):
+        from pepe.embedders.huggingface_embedder import ESM2Embedder
+
+        self.assertIs(self._select_with_type("esm"), ESM2Embedder)
+
+    def test_t5_config_routes_to_t5_embedder(self):
+        from pepe.embedders.huggingface_embedder import T5Embedder
+
+        self.assertIs(self._select_with_type("t5"), T5Embedder)
+
+    def test_roformer_config_routes_to_antiberta2_embedder(self):
+        from pepe.embedders.huggingface_embedder import Antiberta2Embedder
+
+        self.assertIs(self._select_with_type("roformer"), Antiberta2Embedder)
+
+    def test_config_overrides_misleading_slug(self):
+        # A repo whose slug says "esm2" but whose config is a BERT must dispatch on
+        # the config, not the name.
+        from pepe.embedders.huggingface_embedder import GenericHuggingFaceEmbedder
+
+        self.assertIs(
+            self._select_with_type("bert", model_name="labX/my-esm2-finetune"),
+            GenericHuggingFaceEmbedder,
+        )
+
+    def test_config_load_failure_raises_actionable_error(self):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=ValueError("Unrecognized model_type foo"),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                select_model("someuser/mystery-model")
+        # Not-found / unrecognized configs surface a clear message rather than a
+        # generic crash.
+        self.assertIn("PyTorch models only", str(ctx.exception))
+
+
+class TestBareWeightNames(unittest.TestCase):
+    """Bare ESM weight names (no slash) are matched by name without a config call."""
+
+    def test_bare_esm2_name(self):
+        from pepe.embedders.huggingface_embedder import ESM2Embedder
+
+        # Must not touch the network: AutoConfig would raise if called.
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=AssertionError("AutoConfig should not be called for bare names"),
+        ):
+            self.assertIs(select_model("esm2_t6_8M_UR50D"), ESM2Embedder)
+
+    def test_bare_esm1_name(self):
+        from pepe.embedders.esm_embedder import ESMEmbedder
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=AssertionError("AutoConfig should not be called for bare names"),
+        ):
+            self.assertIs(select_model("esm1b_t33_650M_UR50S"), ESMEmbedder)
+
+    def test_unsupported_bare_name_raises(self):
+        with self.assertRaises(ValueError):
+            select_model("not-a-real-model")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_parse_arguments.py
+++ b/src/tests/test_parse_arguments.py
@@ -34,6 +34,7 @@ class TestParseArguments(unittest.TestCase):
         self.assertEqual(args.output_path, "out")
         self.assertEqual(args.extract_embeddings, ["mean_pooled"])
         self.assertTrue(args.streaming_output)
+        self.assertEqual(args.layers, [[-1]])
 
     def test_device_defaults_to_cuda(self):
         args = self._parse(


### PR DESCRIPTION
Promotes `test` to `main` as the **1.3.0** release. On merge, the main-branch publish workflow builds and uploads **1.3.0 to production PyPI**.

Head is `release/1.3.0` = current `test` **plus one commit** bumping `__version__` 1.2.1 → 1.3.0 and cutting the changelog. (The bump couldn't be pushed directly to `test`, so it rides on this branch.) The content is otherwise identical to `test`.

## Why 1.3.0 (MINOR)
`main`/PyPI is still 1.1.1. Everything on `test` since then is additive and backward compatible, so this is a MINOR bump:
- ESM-2 loaded via HuggingFace `transformers`; ESMC support (`biohub/ESMC-*`).
- Broader HuggingFace model compatibility — BERT-like / unrecognized architectures fall back to the generic embedder; config-first dispatch (PR #10).
- CI test workflow, CONTRIBUTING, changelog, `rjieba` runtime dep, MIT license-classifier fix.
- Node 24 GitHub Actions bump.

Full detail in the dated `[1.3.0]` changelog section.

## Release checklist
- [x] `__version__` = `1.3.0`, no `-dev`/`-test` suffix
- [x] `CHANGELOG.md` `[Unreleased]` cut into dated `[1.3.0]`
- [ ] CI green on this PR
- [ ] (recommended) TestPyPI dry-run of 1.3.0 before merging to prod
- [ ] Tag `v1.3.0` after merge

## Note on branch drift
After this merges, `main` will be one commit (the bump) ahead of `test`. To keep them from diverging, sync the bump back to `test` (merge `main` → `test`, or merge `release/1.3.0` → `test`). I can open that sync PR on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)