### PR TITLE
Sync main → test (1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ truth that drives publishing).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-07
+
 ### Added
 - Broader model compatibility: BERT-like and other unrecognized HuggingFace
   architectures now fall back to the generic `AutoModel`-based embedder instead

--- a/src/pepe/__init__.py
+++ b/src/pepe/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     pass
 
 # Package metadata - single source of truth
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 __package_name__ = "pepe-cli"
 __module_name__ = "pepe"
 __author__ = "Jahn Zhong"


### PR DESCRIPTION
Brings `test` up to `main` after the 1.3.0 release (PR #11), so the two branches don't drift.

`main` is ahead of `test` by only the release commits (version bump 1.2.1 → 1.3.0 + changelog cut + the #11 merge). `test` has nothing `main` lacks, so this is a clean, conflict-free sync. After merge, `test` and `main` are content-identical at `__version__` 1.3.0.

Merging this pushes to `test`, which triggers a TestPyPI publish of 1.3.0 (harmless — production PyPI already has 1.3.0 from PR #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)