### PR TITLE
Generic HuggingFace path fixes and preflight checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,9 @@ jobs:
           python -m pytest -v \
             src/tests/test_parse_arguments.py \
             src/tests/test_device_logic.py \
-            src/tests/test_load_layers_default.py
+            src/tests/test_load_layers_default.py \
+            src/tests/test_model_selection.py \
+            src/tests/test_generic_safeguards.py
 
   integration:
     name: Integration tests (downloads a small model)
@@ -63,3 +65,7 @@ jobs:
           python -m pytest -v \
             src/tests/test_api_unittest.py \
             src/tests/test_splitting.py
+      - name: Run generic HuggingFace embedder integration test
+        run: |
+          GENERIC_HF_TEST=1 python -m pytest -v \
+            src/tests/test_generic_hf_integration.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ truth that drives publishing).
 ## [Unreleased]
 
 ### Added
+- Typed model-selection errors (`ModelNotFoundError`, `GatedModelError`,
+  `RemoteCodeRequiredError`, `UnsupportedArchitectureError`,
+  `ModelEnvironmentError`, `ESMCForkRequiredError`) with actionable messages
+  when HuggingFace config or model loading fails.
+- Gated integration test for the generic HuggingFace embedder path
+  (`GENERIC_HF_TEST=1`; downloads `hf-internal-testing/tiny-random-BertModel`).
+  CI runs it in the integration job (model-download) while the unit job stays
+  download-free.
+- `--trust_remote_code` CLI/API flag to opt in to HuggingFace custom modeling code
+  (default off; documented security risk in `--help`).
+- `pepe --check_model <repo>` dry-run that loads config and tokenizer only and
+  prints architecture, embedder choice, max length, tokenizer type, and output
+  capabilities before any embedding run.
 - Broader model compatibility: BERT-like and other unrecognized HuggingFace
   architectures now fall back to the generic `AutoModel`-based embedder instead
   of raising, so standard protein encoders such as ProtBert, AntiBERTy and
@@ -32,6 +45,10 @@ truth that drives publishing).
   installed it manually; CI now guards against this regression.
 
 ### Changed
+- HuggingFace config/load failures are classified by upstream exception type
+  instead of string-sniffing on error messages (`model_errors.py`).
+- Generic HuggingFace model loading no longer auto-enables `trust_remote_code`
+  based on repo name patterns; use `--trust_remote_code` explicitly when needed.
 - Model dispatch (`model_selecter.py`) now inspects a HuggingFace repo's config
   (`AutoConfig.model_type`) before matching on its name. A fine-tune whose repo
   slug contains "esm2" but whose architecture is something else is no longer
@@ -44,6 +61,12 @@ truth that drives publishing).
   `pypa/gh-action-pypi-publish` is Docker-based and unaffected.
 
 ### Fixed
+- Generic HuggingFace embedder (`GenericHuggingFaceEmbedder`) now mirrors ESM-2
+  safeguards: length-limit detection and optional sequence splitting via
+  `_check_max_input_length`, eager attention when extracting contacts, and a
+  warning when the tokenizer is subword-based (per-residue outputs may be
+  misaligned). Sentinel `tokenizer.model_max_length` values (~1e30) are treated
+  as unknown limits instead of a real cap.
 - Corrected the PyPI license classifier from "GNU Affero General Public License
   v3" to "MIT License" in `pyproject.toml` and `setup.py`, matching the actual
   `LICENSE` file.

--- a/src/pepe/__main__.py
+++ b/src/pepe/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pepe.parse_arguments import parse_arguments
 
 logger = logging.getLogger("src.__main__")
@@ -7,10 +8,32 @@ logger = logging.getLogger("src.__main__")
 def main():
     args = parse_arguments()
 
+    if args.check_model:
+        from pepe.model_selecter import report_model
+
+        report_model(args.check_model, trust_remote_code=args.trust_remote_code)
+        return
+
+    missing = []
+    if not args.model_name:
+        missing.append("--model_name")
+    if not args.fasta_path:
+        missing.append("--fasta_path")
+    if not args.output_path:
+        missing.append("--output_path")
+    if missing:
+        print(
+            f"Error: the following arguments are required: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     # Lazy import to avoid loading heavy dependencies during --help
     from pepe.model_selecter import select_model
 
-    selected_model = select_model(args.model_name)
+    selected_model = select_model(
+        args.model_name, trust_remote_code=args.trust_remote_code
+    )
 
     embedder = selected_model(args)
 

--- a/src/pepe/api.py
+++ b/src/pepe/api.py
@@ -90,6 +90,7 @@ def embed(
         "split_long_sequences": kwargs.get("split_long_sequences", False),
         "split_overlap": kwargs.get("split_overlap", 0),
         "force_split_length": kwargs.get("force_split_length"),
+        "trust_remote_code": kwargs.get("trust_remote_code", False),
         "num_workers": kwargs.get("num_workers", 8),
         "disable_special_tokens": kwargs.get("disable_special_tokens", False),
         "flatten": kwargs.get("flatten", False),
@@ -98,7 +99,9 @@ def embed(
     
     args = SimpleNamespace(**args_dict)
     
-    selected_model_class = select_model(model_name)
+    selected_model_class = select_model(
+        model_name, trust_remote_code=args.trust_remote_code
+    )
     embedder = selected_model_class(args)
     embedder.run()
     

--- a/src/pepe/embedders/base_embedder.py
+++ b/src/pepe/embedders/base_embedder.py
@@ -57,6 +57,7 @@ class BaseEmbedder:
         self.split_long_sequences = getattr(args, "split_long_sequences", False)
         self.split_overlap = getattr(args, "split_overlap", 0)
         self.force_split_length = getattr(args, "force_split_length", None)
+        self.trust_remote_code = getattr(args, "trust_remote_code", False)
         self.chunks_mapping = {}  # Map original label to list of chunk labels
         self.chunk_payload_lengths = {} # Map chunk label to its payload length
         self.original_sequences = {} # Store original sequence for reference
@@ -843,14 +844,14 @@ class BaseEmbedder:
         if max_allowed is None:
             return
 
-        # Check if splitting is needed (either by explicit max_input_length or by reviewing sequences)
-        needs_splitting = False
-        if isinstance(self.max_input_length, int) and self.max_input_length > max_allowed:
-            needs_splitting = True
-        elif self.split_long_sequences:
-            # Check if any individual sequence exceeds the limit
-            if any(len(s) > (max_allowed - 2) for s in self.sequences.values()): # -2 for cls/eos
-                needs_splitting = True
+        # Check if any sequence exceeds the model limit (-2 for cls/eos special tokens)
+        sequences_too_long = any(
+            len(s) > (max_allowed - 2) for s in self.sequences.values()
+        )
+        needs_splitting = (
+            isinstance(self.max_input_length, int)
+            and self.max_input_length > max_allowed
+        ) or sequences_too_long
 
         if needs_splitting:
             if self.split_long_sequences:
@@ -863,27 +864,61 @@ class BaseEmbedder:
                     f"Warning: Sequences exceed the model's maximum allowed length ({max_allowed})."
                 )
 
+    _UNKNOWN_MAX_LENGTH_THRESHOLD = 1e9
+
+    @classmethod
+    def _is_unknown_max_length(cls, value):
+        """Treat HuggingFace sentinel model_max_length (~1e30) as unknown."""
+        try:
+            return float(value) >= cls._UNKNOWN_MAX_LENGTH_THRESHOLD
+        except (TypeError, ValueError):
+            return False
+
     def _get_model_max_allowed(self):
         """Estimate the maximum allowed sequence length for the model."""
         if hasattr(self, "force_split_length") and self.force_split_length is not None:
             return self.force_split_length
 
         max_allowed = None
+        max_source = None
         if hasattr(self, "model"):
-            if hasattr(self.model, "config") and hasattr(self.model.config, "max_position_embeddings"):
+            if hasattr(self.model, "config") and hasattr(
+                self.model.config, "max_position_embeddings"
+            ):
                 max_allowed = self.model.config.max_position_embeddings
-            elif hasattr(self, "tokenizer") and hasattr(self.tokenizer, "model_max_length"):
+                max_source = "config.max_position_embeddings"
+            elif hasattr(self, "tokenizer") and hasattr(
+                self.tokenizer, "model_max_length"
+            ):
                 max_allowed = self.tokenizer.model_max_length
-            
+                max_source = "tokenizer.model_max_length"
+
             if max_allowed is None and hasattr(self.model, "max_positions"):
                 max_allowed = getattr(self.model, "max_positions", None)
                 if callable(max_allowed):
                     max_allowed = max_allowed()
-                elif hasattr(self.model, "max_positions") and isinstance(self.model.max_positions, int):
+                elif hasattr(self.model, "max_positions") and isinstance(
+                    self.model.max_positions, int
+                ):
                     max_allowed = self.model.max_positions
-                    
-            if max_allowed is None and hasattr(self.model, "config") and hasattr(self.model.config, "n_positions"):
+                max_source = "model.max_positions"
+
+            if (
+                max_allowed is None
+                and hasattr(self.model, "config")
+                and hasattr(self.model.config, "n_positions")
+            ):
                 max_allowed = self.model.config.n_positions
+                max_source = "config.n_positions"
+
+        if max_allowed is not None and self._is_unknown_max_length(max_allowed):
+            logger.info(
+                "Model maximum sequence length is unknown (%s=%s); "
+                "length limits will not be enforced automatically.",
+                max_source or "max_length",
+                max_allowed,
+            )
+            return None
         return max_allowed
 
     def _handle_sequence_splitting(self, max_allowed):

--- a/src/pepe/embedders/huggingface_embedder.py
+++ b/src/pepe/embedders/huggingface_embedder.py
@@ -249,8 +249,12 @@ class T5Embedder(HuggingfaceEmbedder):
             AutoModelForMaskedLM,
         ) = _import_transformers()
 
-        tokenizer = T5Tokenizer.from_pretrained(model_link, use_fast=True)
-        model = T5EncoderModel.from_pretrained(model_link).to(device)  # type: ignore
+        tokenizer = T5Tokenizer.from_pretrained(
+            model_link, use_fast=True, trust_remote_code=self.trust_remote_code
+        )
+        model = T5EncoderModel.from_pretrained(
+            model_link, trust_remote_code=self.trust_remote_code
+        ).to(device)  # type: ignore
         model.eval()
         num_heads = model.config.num_heads
         num_layers = model.config.num_layers
@@ -281,6 +285,7 @@ class ESM2Embedder(HuggingfaceEmbedder):
         self.valid_tokens = self._get_valid_tokens()
         self.bracket_type = pepe.utils.get_bracket_type(self.tokenizer)
         self._check_max_input_length()
+        pepe.utils.warn_if_non_character_tokenizer(self.tokenizer, self.model_name)
         pepe.utils.check_input_tokens(
             self.valid_tokens,
             self.sequences,
@@ -343,8 +348,10 @@ class ESM2Embedder(HuggingfaceEmbedder):
         ) = _import_transformers()
 
         logger.info(f"Loading ESM-2 model from HuggingFace: {model_link}")
-        tokenizer = AutoTokenizer.from_pretrained(model_link)
-        model_kwargs = {}
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_link, trust_remote_code=self.trust_remote_code
+        )
+        model_kwargs = {"trust_remote_code": self.trust_remote_code}
         if self.return_contacts:
             model_kwargs["attn_implementation"] = "eager"
 
@@ -540,8 +547,13 @@ class GenericHuggingFaceEmbedder(HuggingfaceEmbedder):
         ) = self._initialize_model(self.model_link)
         self.valid_tokens = self._get_valid_tokens()
         self.bracket_type = pepe.utils.get_bracket_type(self.tokenizer)
+        self._check_max_input_length()
+        pepe.utils.warn_if_non_character_tokenizer(self.tokenizer, self.model_name)
         pepe.utils.check_input_tokens(
-            self.valid_tokens, self.sequences, self.model_name
+            self.valid_tokens,
+            self.sequences,
+            self.model_name,
+            split_long_sequences=self.split_long_sequences,
         )
         self.special_tokens = torch.tensor(
             self.tokenizer.all_special_ids, device=self.device, dtype=torch.int8
@@ -590,54 +602,49 @@ class GenericHuggingFaceEmbedder(HuggingfaceEmbedder):
             AutoModelForMaskedLM,
         ) = _import_transformers()
 
-        # For models that commonly require custom code, use trust_remote_code=True immediately
-        requires_custom_code = any(
-            pattern in model_link.lower()
-            for pattern in ["progen", "protgpt", "esm-fold", "esmfold", "alphafold"]
-        )
+        from pepe.model_errors import translate_hf_config_error
 
-        if requires_custom_code:
-            tokenizer = AutoTokenizer.from_pretrained(
-                model_link, use_fast=True, trust_remote_code=True
-            )
+        model_kwargs = {"trust_remote_code": self.trust_remote_code}
+        if self.return_contacts:
+            model_kwargs["attn_implementation"] = "eager"
+        attn_fallback_attempted = False
+
+        def _load_pretrained(model_cls, link, **extra_kwargs):
+            nonlocal attn_fallback_attempted
+            kwargs = {**model_kwargs, **extra_kwargs}
             try:
-                model = AutoModel.from_pretrained(
-                    model_link, trust_remote_code=True
-                ).to(device)
-            except ValueError as model_error:
-                # If AutoModel fails, try AutoModelForCausalLM
-                model = AutoModelForCausalLM.from_pretrained(
-                    model_link, trust_remote_code=True
-                ).to(device)
-        else:
-            # Try without trust_remote_code first, then with it if needed
-            try:
-                tokenizer = AutoTokenizer.from_pretrained(model_link, use_fast=True)
-                try:
-                    model = AutoModel.from_pretrained(model_link).to(device)
-                except ValueError as model_error:
-                    # If AutoModel fails, try AutoModelForCausalLM
-                    model = AutoModelForCausalLM.from_pretrained(model_link).to(device)
-            except (OSError, ValueError) as e:
-                # If the model requires custom code, try with trust_remote_code=True
+                return model_cls.from_pretrained(link, **kwargs).to(device)
+            except (TypeError, ValueError) as load_error:
                 if (
-                    "trust_remote_code" in str(e).lower()
-                    or "custom code" in str(e).lower()
+                    model_kwargs.get("attn_implementation")
+                    and not attn_fallback_attempted
                 ):
-                    tokenizer = AutoTokenizer.from_pretrained(
-                        model_link, use_fast=True, trust_remote_code=True
+                    attn_fallback_attempted = True
+                    logger.warning(
+                        "Model rejected attn_implementation='eager' (%s); "
+                        "attention extraction may be unavailable.",
+                        load_error,
                     )
-                    try:
-                        model = AutoModel.from_pretrained(
-                            model_link, trust_remote_code=True
-                        ).to(device)
-                    except ValueError as model_error:
-                        # If AutoModel fails, try AutoModelForCausalLM
-                        model = AutoModelForCausalLM.from_pretrained(
-                            model_link, trust_remote_code=True
-                        ).to(device)
-                else:
-                    raise
+                    model_kwargs.pop("attn_implementation", None)
+                    kwargs = {**model_kwargs, **extra_kwargs}
+                    return model_cls.from_pretrained(link, **kwargs).to(device)
+                raise
+
+        def _load_model(link, **extra_kwargs):
+            try:
+                return _load_pretrained(AutoModel, link, **extra_kwargs)
+            except ValueError:
+                return _load_pretrained(AutoModelForCausalLM, link, **extra_kwargs)
+
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_link, use_fast=True, trust_remote_code=self.trust_remote_code
+            )
+            model = _load_model(model_link)
+        except Exception as e:
+            translate_hf_config_error(
+                model_link, e, trust_remote_code=self.trust_remote_code
+            )
 
         # Handle tokenizer padding token
         if tokenizer.pad_token is None:

--- a/src/pepe/model_errors.py
+++ b/src/pepe/model_errors.py
@@ -1,0 +1,130 @@
+"""Typed errors for HuggingFace model selection and loading."""
+
+
+class ModelSelectionError(ValueError):
+    """Base class for model dispatch / config load failures."""
+
+
+class ModelNotFoundError(ModelSelectionError):
+    """HuggingFace repository id does not exist on the Hub."""
+
+
+class GatedModelError(ModelSelectionError):
+    """HuggingFace repository is gated and requires authentication."""
+
+
+class RemoteCodeRequiredError(ModelSelectionError):
+    """Model ships custom code that must be explicitly trusted."""
+
+
+class UnsupportedArchitectureError(ModelSelectionError):
+    """Model architecture is not supported by PEPE (e.g. Keras/TensorFlow)."""
+
+
+class ModelEnvironmentError(ModelSelectionError):
+    """Network, cache, or filesystem failure while loading model metadata."""
+
+
+class ESMCForkRequiredError(ModelSelectionError):
+    """ESMC models require Biohub's transformers fork."""
+
+
+def _import_hf_hub_errors():
+    """Lazy import of huggingface_hub exception types (version-tolerant)."""
+    try:
+        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+
+        return RepositoryNotFoundError, GatedRepoError
+    except ImportError:
+        try:
+            from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+
+            return RepositoryNotFoundError, GatedRepoError
+        except ImportError:
+            return None, None
+
+
+_REMOTE_CODE_MARKERS = (
+    "trust_remote_code",
+    "requires you to execute",
+    "custom code",
+)
+
+
+def requires_remote_code(error):
+    """Return True when upstream signals that trust_remote_code is required."""
+    msg = str(error).lower()
+    return any(marker in msg for marker in _REMOTE_CODE_MARKERS)
+
+
+def _is_unsupported_architecture_error(error):
+    if not isinstance(error, ValueError):
+        return False
+    msg = str(error)
+    return "Unrecognized model" in msg or (
+        "model_type" in msg and "esmc" not in msg.lower()
+    )
+
+
+def _is_esmc_fork_error(model_name, error):
+    if "esmc" not in model_name.lower():
+        return False
+    if _is_unsupported_architecture_error(error):
+        return True
+    return "esmc" in str(error).lower()
+
+
+def _esmc_fork_message():
+    return (
+        "ESMC models require Biohub's transformers fork (ESM1 fair-esm is unaffected). "
+        "Install with: pip install git+https://github.com/Biohub/transformers.git@main"
+    )
+
+
+def translate_hf_config_error(model_name, error, *, trust_remote_code=False):
+    """Map an AutoConfig load failure to a typed, actionable ModelSelectionError."""
+    if _is_esmc_fork_error(model_name, error):
+        raise ESMCForkRequiredError(_esmc_fork_message()) from error
+
+    repository_not_found_error, gated_repo_error = _import_hf_hub_errors()
+
+    if gated_repo_error is not None and isinstance(error, gated_repo_error):
+        if "esmc" in model_name.lower():
+            raise ESMCForkRequiredError(_esmc_fork_message()) from error
+        raise GatedModelError(
+            f"HuggingFace model '{model_name}' is gated and requires authentication. "
+            f"Log in with `huggingface-cli login` and accept the model's terms on the Hub, "
+            f"then retry."
+        ) from error
+
+    if repository_not_found_error is not None and isinstance(
+        error, repository_not_found_error
+    ):
+        raise ModelNotFoundError(
+            f"HuggingFace model '{model_name}' was not found. Check the repo id for typos "
+            f"and confirm it exists on https://huggingface.co/models."
+        ) from error
+
+    if requires_remote_code(error) and not trust_remote_code:
+        raise RemoteCodeRequiredError(
+            f"Model '{model_name}' requires custom modeling code from the Hub. "
+            f"Re-run with --trust_remote_code (CLI) or trust_remote_code=True (embed()). "
+            f"Only enable this for repos you trust — it executes remote Python code."
+        ) from error
+
+    if _is_unsupported_architecture_error(error):
+        raise UnsupportedArchitectureError(
+            f"Model {model_name} appears to be a Keras/TensorFlow model or has an "
+            f"unsupported architecture. PEPE currently supports PyTorch models only. "
+            f"Consider using a PyTorch version or converting the model."
+        ) from error
+
+    if isinstance(error, (OSError, EnvironmentError)):
+        raise ModelEnvironmentError(
+            f"Could not reach HuggingFace to load config for '{model_name}' "
+            f"(network, cache, or filesystem issue): {error}"
+        ) from error
+
+    raise ModelSelectionError(
+        f"Could not load model config for {model_name}: {error}"
+    ) from error

--- a/src/pepe/model_selecter.py
+++ b/src/pepe/model_selecter.py
@@ -1,4 +1,5 @@
 from pepe.embedders.custom_embedder import CustomEmbedder
+from pepe.model_errors import translate_hf_config_error
 
 import os
 
@@ -38,7 +39,7 @@ def _get_generic_hf_embedder():
     return GenericHuggingFaceEmbedder
 
 
-def select_model(model_name):
+def select_model(model_name, trust_remote_code=False):
     # 1. Local checkpoints / directories take precedence over any name heuristic,
     #    so a local file or folder is never mistaken for a HuggingFace repo id or a
     #    bare weight name (e.g. a directory called "my_esm2_run/").
@@ -58,7 +59,7 @@ def select_model(model_name):
     #    signal: a fine-tune whose slug says "esm2" but is really a BERT no longer
     #    gets mis-routed.
     if "/" in model_name:
-        return _select_hf_model(model_name)
+        return _select_hf_model(model_name, trust_remote_code=trust_remote_code)
 
     # 3. Bare weight names (no slash) are fair-esm / facebook ESM weight sets, which
     #    have no downloadable config to inspect. Match on the name for these only.
@@ -74,7 +75,7 @@ def select_model(model_name):
     )
 
 
-def _select_hf_model(model_name):
+def _select_hf_model(model_name, trust_remote_code=False):
     """Dispatch a HuggingFace repo id to an embedder by inspecting its config.
 
     Known architectures get their specialized embedder; everything else (BERT-like
@@ -86,9 +87,13 @@ def _select_hf_model(model_name):
     try:
         from transformers import AutoConfig
 
-        config = AutoConfig.from_pretrained(model_name)
+        config = AutoConfig.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code
+        )
     except Exception as e:
-        _raise_hf_config_error(model_name, e)
+        translate_hf_config_error(
+            model_name, e, trust_remote_code=trust_remote_code
+        )
 
     model_type = (getattr(config, "model_type", "") or "").lower()
 
@@ -114,21 +119,85 @@ def _select_hf_model(model_name):
     return _get_generic_hf_embedder()
 
 
-def _raise_hf_config_error(model_name, error):
-    """Translate an AutoConfig load failure into an actionable ValueError."""
-    error_msg = str(error)
-    if "esmc" in model_name.lower() or "esmc" in error_msg.lower():
-        raise ValueError(
-            f"ESMC models require Biohub's transformers fork (ESM1 fair-esm is unaffected). "
-            f"Install with: pip install git+https://github.com/Biohub/transformers.git@main"
-        ) from error
-    if "Unrecognized model" in error_msg or "model_type" in error_msg:
-        raise ValueError(
-            f"Model {model_name} appears to be a Keras/TensorFlow model or has an unsupported architecture. PEPE currently supports PyTorch models only. Consider using a PyTorch version or converting the model."
-        ) from error
-    raise ValueError(
-        f"Could not load model config for {model_name}: {error}"
-    ) from error
+_MODEL_MAX_LENGTH_SENTINEL = 1_000_000_000
+
+
+def _format_max_length(config, tokenizer):
+    """Return a human-readable max sequence length, ignoring HF sentinel values."""
+    if hasattr(config, "max_position_embeddings") and config.max_position_embeddings:
+        val = config.max_position_embeddings
+        if val < _MODEL_MAX_LENGTH_SENTINEL:
+            return str(val)
+
+    if hasattr(tokenizer, "model_max_length"):
+        val = tokenizer.model_max_length
+        if val < _MODEL_MAX_LENGTH_SENTINEL:
+            return str(val)
+        return "unknown (no enforced limit)"
+
+    if hasattr(config, "n_positions") and config.n_positions:
+        val = config.n_positions
+        if val < _MODEL_MAX_LENGTH_SENTINEL:
+            return str(val)
+
+    return "unknown"
+
+
+def report_model(model_name, trust_remote_code=False):
+    """Load config + tokenizer only and print a compatibility summary."""
+    import pepe.utils
+
+    from transformers import AutoConfig, AutoTokenizer
+
+    try:
+        config = AutoConfig.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code
+        )
+    except Exception as e:
+        translate_hf_config_error(
+            model_name, e, trust_remote_code=trust_remote_code
+        )
+
+    embedder_cls = select_model(model_name, trust_remote_code=trust_remote_code)
+    embedder_name = embedder_cls.__name__
+    model_type = getattr(config, "model_type", None) or "unknown"
+    max_length = _format_max_length(config, tokenizer)
+    char_level = pepe.utils.is_character_tokenizer(tokenizer)
+    if char_level:
+        tokenizer_type = "character-level"
+    else:
+        tokenizer_type = (
+            "subword (per_token/substring_pooled unreliable; prefer mean_pooled)"
+        )
+
+    logits_available = embedder_name == "ESM2Embedder"
+
+    if embedder_name in ("ESMEmbedder",):
+        attention = "yes (fair-esm contacts)"
+    elif embedder_name == "GenericHuggingFaceEmbedder":
+        attention = "yes (attn_implementation=eager may be required)"
+    elif embedder_name in (
+        "ESM2Embedder",
+        "Antiberta2Embedder",
+        "ESMCEmbedder",
+        "T5Embedder",
+    ):
+        attention = "yes"
+    elif embedder_name == "CustomEmbedder":
+        attention = "depends on model"
+    else:
+        attention = "unknown"
+
+    print(f"Model:           {model_name}")
+    print(f"Architecture:    {model_type}")
+    print(f"Embedder:        {embedder_name}")
+    print(f"Max length:      {max_length}")
+    print(f"Tokenizer:       {tokenizer_type}")
+    print(f"Logits:          {'yes' if logits_available else 'no'}")
+    print(f"Attention:       {attention}")
 
 
 supported_models = [

--- a/src/pepe/parse_arguments.py
+++ b/src/pepe/parse_arguments.py
@@ -41,9 +41,16 @@ def parse_arguments():
         help="Name of the experiment. Will be used to name the output files. If not provided, the output files will be named after the input file.",
     )
     parser.add_argument(
+        "--check_model",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help="Dry-run: load config and tokenizer for NAME, print compatibility summary, and exit without embedding.",
+    )
+    parser.add_argument(
         "--model_name",
         type=str,
-        required=True,
+        required=False,
         help="Model name or path to custom model. For custom models, use path to .pt/.pth file or directory containing model files. For predefined models, use model name from supported list.",
     )
     parser.add_argument(
@@ -55,14 +62,14 @@ def parse_arguments():
     parser.add_argument(
         "--fasta_path",
         type=str,
-        required=True,
-        help="Path to the input FASTA file. Required. If no experiment name is provided, the output files will be named after the input file.",
+        required=False,
+        help="Path to the input FASTA file. Required unless --check_model is used. If no experiment name is provided, the output files will be named after the input file.",
     )
     parser.add_argument(
         "--output_path",
         type=str,
-        required=True,
-        help="Directory for output files \n Will generate a subdirectory for outputs of each output_type.\n Will output multiple files if multiple layers are specified with '--layers'. Output file is a single tensor or a list of tensors when --pooling is False.",
+        required=False,
+        help="Directory for output files \n Will generate a subdirectory for outputs of each output_type.\n Will output multiple files if multiple layers are specified with '--layers'. Output file is a single tensor or a list of tensors when --pooling is False. Required unless --check_model is used.",
     )
     parser.add_argument(
         "--substring_path",
@@ -121,6 +128,12 @@ def parse_arguments():
         "--split_long_sequences",
         action="store_true",
         help="If a sequence exceeds the maximum permitted length for the chosen model, split it into smaller overlapping chunks and concatenate the output representations.",
+    )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Allow HuggingFace to download and execute custom Python code from the model repo. "
+        "Required for some models but runs arbitrary code from the repository — only enable for repos you trust.",
     )
     parser.add_argument(
         "--split_overlap",

--- a/src/pepe/utils.py
+++ b/src/pepe/utils.py
@@ -481,6 +481,30 @@ def check_input_tokens(
     logger.info("No invalid tokens in input sequences.")
 
 
+_CHARACTER_TOKENIZER_PROBE = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def is_character_tokenizer(tokenizer) -> bool:
+    """Return True when one amino acid maps to one token (no subword merging)."""
+    encoded = tokenizer.encode(
+        _CHARACTER_TOKENIZER_PROBE, add_special_tokens=False
+    )
+    return len(encoded) == len(_CHARACTER_TOKENIZER_PROBE)
+
+
+def warn_if_non_character_tokenizer(tokenizer, model_name=None):
+    """Log a prominent warning when the tokenizer is not character-level."""
+    if is_character_tokenizer(tokenizer):
+        return
+    name = model_name or "this model"
+    logger.warning(
+        "Warning: %s uses a subword tokenizer (not one amino acid per token). "
+        "per_token and substring_pooled outputs will NOT align with residues; "
+        "use mean_pooled for reliable sequence-level embeddings.",
+        name,
+    )
+
+
 def fasta_to_dict(fasta_path):
     """Convert FASTA file into a dictionary: {id: raw_sequence}."""
     seq_dict = {}

--- a/src/tests/test_generic_hf_integration.py
+++ b/src/tests/test_generic_hf_integration.py
@@ -1,0 +1,57 @@
+"""End-to-end integration test for the generic HuggingFace embedder path.
+
+Mocked dispatch tests live in test_model_selection.py. This file downloads a
+real tiny encoder from the Hub and runs pepe.embed() end-to-end.
+
+Run the gated integration test locally:
+
+    GENERIC_HF_TEST=1 python -m pytest src/tests/test_generic_hf_integration.py -v
+
+Requires network access and transformers/torch (installed with pepe-cli).
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath("src"))
+
+
+@unittest.skipUnless(
+    os.environ.get("GENERIC_HF_TEST") == "1",
+    "Set GENERIC_HF_TEST=1 to run generic HuggingFace integration test "
+    "(downloads hf-internal-testing/tiny-random-BertModel from the Hub)",
+)
+class TestGenericHFIntegration(unittest.TestCase):
+    MODEL = "hf-internal-testing/tiny-random-BertModel"
+
+    def test_tiny_bert_mean_pooled_end_to_end(self):
+        import pepe
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(self.MODEL)
+        expected_hidden = config.hidden_size
+
+        sequences = {
+            # tiny-random-BertModel uses a multilingual WordPiece vocab; pick tokens
+            # that exist as single-character entries so check_input_tokens passes.
+            "seq1": '!"#$%',
+        }
+        results = pepe.embed(
+            model_name=self.MODEL,
+            sequences=sequences,
+            extract_embeddings=["mean_pooled"],
+            layers=[[-1]],
+            device="cpu",
+            streaming_output=False,
+        )
+
+        self.assertIn("mean_pooled", results)
+        layer_outputs = results["mean_pooled"]
+        layer_key = next(iter(layer_outputs))
+        self.assertEqual(len(layer_outputs[layer_key]), 1)
+        self.assertEqual(layer_outputs[layer_key][0].shape, (expected_hidden,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_generic_safeguards.py
+++ b/src/tests/test_generic_safeguards.py
@@ -1,0 +1,235 @@
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from pepe.embedders.base_embedder import BaseEmbedder
+from pepe.embedders.huggingface_embedder import GenericHuggingFaceEmbedder
+from pepe.utils import is_character_tokenizer, warn_if_non_character_tokenizer
+
+
+def _make_args(fasta_path, split_long_sequences=False, extract_embeddings=None):
+    class DummyArgs:
+        pass
+
+    args = DummyArgs()
+    args.fasta_path = fasta_path
+    args.output_path = tempfile.mkdtemp()
+    args.experiment_name = "test"
+    args.model_name = "someuser/tiny-bert"
+    args.disable_special_tokens = False
+    args.substring_path = None
+    args.context = 0
+    args.layers = [[-1]]
+    args.batch_size = 1024
+    args.max_input_length = "max_input_length"
+    args.device = "cpu"
+    args.extract_embeddings = extract_embeddings or ["mean_pooled"]
+    args.discard_padding = False
+    args.flatten = False
+    args.streaming_output = False
+    args.precision = "32"
+    args.flush_batches_after = 128
+    args.split_long_sequences = split_long_sequences
+    args.split_overlap = 50
+    args.force_split_length = None
+    args.num_workers = 1
+    return args
+
+
+def _mock_model_tokenizer(max_position_embeddings=512, char_level=True):
+    config = MagicMock()
+    config.model_type = "bert"
+    config.max_position_embeddings = max_position_embeddings
+    config.num_attention_heads = 8
+    config.num_hidden_layers = 2
+    config.hidden_size = 64
+
+    model = MagicMock()
+    model.config = config
+    model.eval = MagicMock()
+
+    probe = "ACDEFGHIKLMNPQRSTVWY"
+
+    def encode(text, add_special_tokens=True):
+        if not char_level and text == probe and not add_special_tokens:
+            return list(range(5))
+        if not add_special_tokens:
+            return list(range(len(text)))
+        return [0] + list(range(len(text))) + [1]
+
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {c: i for i, c in enumerate(probe)}
+    tokenizer.all_special_ids = [0, 1]
+    tokenizer.all_special_tokens = ["[CLS]", "[SEP]"]
+    tokenizer.special_tokens_map = {"additional_special_tokens": ["[CLS]"]}
+    tokenizer.pad_token = "[PAD]"
+    tokenizer.encode = encode
+    tokenizer.model_max_length = max_position_embeddings
+    return model, tokenizer
+
+
+class TestGenericLengthSafety(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir = tempfile.mkdtemp()
+        cls.fasta_path = os.path.join(cls.test_dir, "long.fasta")
+        with open(cls.fasta_path, "w") as f:
+            f.write(f">long_prot\n{'A' * 600}\n")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.test_dir, ignore_errors=True)
+
+    def _build_embedder(self, split_long_sequences):
+        args = _make_args(self.fasta_path, split_long_sequences=split_long_sequences)
+        model, tokenizer = _mock_model_tokenizer(max_position_embeddings=512)
+        with patch.object(
+            GenericHuggingFaceEmbedder,
+            "_initialize_model",
+            return_value=(model, tokenizer, 8, 2, 64),
+        ), patch.object(
+            GenericHuggingFaceEmbedder, "_load_data", return_value=(MagicMock(), 512)
+        ), patch.object(GenericHuggingFaceEmbedder, "_set_output_objects"):
+            return GenericHuggingFaceEmbedder(args)
+
+    def test_splits_when_split_long_sequences_enabled(self):
+        embedder = self._build_embedder(split_long_sequences=True)
+        self.assertIn("long_prot", embedder.chunks_mapping)
+        self.assertGreater(len(embedder.chunks_mapping["long_prot"]), 1)
+
+    def test_warns_when_split_long_sequences_disabled(self):
+        with self.assertLogs("src.embedders.base_embedder", level="WARNING") as logs:
+            self._build_embedder(split_long_sequences=False)
+        self.assertTrue(
+            any("exceed the model's maximum allowed length" in msg for msg in logs.output)
+        )
+
+
+class TestGenericAttentionKwargs(unittest.TestCase):
+    def test_eager_attn_when_return_contacts(self):
+        args = _make_args(
+            os.path.join(os.path.dirname(__file__), "test_files", "test.fasta"),
+            extract_embeddings=["attention_layer"],
+        )
+        recorded = []
+
+        mock_model, mock_tokenizer = _mock_model_tokenizer()
+        mock_model.to.return_value = mock_model
+
+        def capture_from_pretrained(link, **kwargs):
+            recorded.append(dict(kwargs))
+            return mock_model
+
+        mock_auto_model = MagicMock()
+        mock_auto_model.from_pretrained = capture_from_pretrained
+        mock_auto_tokenizer = MagicMock()
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        with patch(
+            "pepe.embedders.huggingface_embedder._import_transformers",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                mock_auto_model,
+                mock_auto_tokenizer,
+                MagicMock(),
+                MagicMock(),
+            ),
+        ):
+            embedder = GenericHuggingFaceEmbedder.__new__(GenericHuggingFaceEmbedder)
+            BaseEmbedder.__init__(embedder, args)
+            embedder._initialize_model("someuser/tiny-bert")
+
+        self.assertTrue(recorded)
+        self.assertEqual(recorded[0].get("attn_implementation"), "eager")
+
+    def test_no_eager_attn_without_return_contacts(self):
+        args = _make_args(
+            os.path.join(os.path.dirname(__file__), "test_files", "test.fasta"),
+            extract_embeddings=["mean_pooled"],
+        )
+        recorded = []
+
+        mock_model, mock_tokenizer = _mock_model_tokenizer()
+        mock_model.to.return_value = mock_model
+
+        def capture_from_pretrained(link, **kwargs):
+            recorded.append(dict(kwargs))
+            return mock_model
+
+        mock_auto_model = MagicMock()
+        mock_auto_model.from_pretrained = capture_from_pretrained
+        mock_auto_tokenizer = MagicMock()
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        with patch(
+            "pepe.embedders.huggingface_embedder._import_transformers",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                mock_auto_model,
+                mock_auto_tokenizer,
+                MagicMock(),
+                MagicMock(),
+            ),
+        ):
+            embedder = GenericHuggingFaceEmbedder.__new__(GenericHuggingFaceEmbedder)
+            BaseEmbedder.__init__(embedder, args)
+            embedder._initialize_model("someuser/tiny-bert")
+
+        self.assertTrue(recorded)
+        self.assertNotIn("attn_implementation", recorded[0])
+
+
+class TestCharacterTokenizerDetection(unittest.TestCase):
+    def test_char_level_tokenizer_is_detected(self):
+        _, tokenizer = _mock_model_tokenizer(char_level=True)
+        self.assertTrue(is_character_tokenizer(tokenizer))
+
+    def test_subword_tokenizer_is_detected(self):
+        _, tokenizer = _mock_model_tokenizer(char_level=False)
+        self.assertFalse(is_character_tokenizer(tokenizer))
+
+    def test_subword_tokenizer_logs_warning(self):
+        _, tokenizer = _mock_model_tokenizer(char_level=False)
+        with self.assertLogs("src.utils", level="WARNING") as logs:
+            warn_if_non_character_tokenizer(tokenizer, "someuser/wordpiece-bert")
+        self.assertTrue(any("subword tokenizer" in msg for msg in logs.output))
+
+    def test_char_level_tokenizer_no_warning(self):
+        _, tokenizer = _mock_model_tokenizer(char_level=True)
+        with patch.object(logging.getLogger("src.utils"), "warning") as mock_warn:
+            warn_if_non_character_tokenizer(tokenizer, "someuser/char-bert")
+        mock_warn.assert_not_called()
+
+
+class TestSentinelModelMaxLength(unittest.TestCase):
+    def test_sentinel_model_max_length_treated_as_unknown(self):
+        embedder = BaseEmbedder.__new__(BaseEmbedder)
+        embedder.force_split_length = None
+        embedder.model = MagicMock()
+        embedder.model.config = MagicMock(spec=[])
+        embedder.tokenizer = MagicMock()
+        embedder.tokenizer.model_max_length = 1000000000000.0
+
+        with self.assertLogs("src.embedders.base_embedder", level="INFO") as logs:
+            result = embedder._get_model_max_allowed()
+
+        self.assertIsNone(result)
+        self.assertTrue(any("unknown" in msg.lower() for msg in logs.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_model_selection.py
+++ b/src/tests/test_model_selection.py
@@ -1,11 +1,21 @@
 import os
 import sys
 import unittest
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath("src"))
 
-from pepe.model_selecter import select_model
+from pepe.model_selecter import select_model, report_model
+from pepe.model_errors import (
+    ESMCForkRequiredError,
+    GatedModelError,
+    ModelEnvironmentError,
+    ModelNotFoundError,
+    ModelSelectionError,
+    RemoteCodeRequiredError,
+    UnsupportedArchitectureError,
+)
 
 
 def _config(model_type):
@@ -66,11 +76,88 @@ class TestHuggingFaceDispatch(unittest.TestCase):
             "transformers.AutoConfig.from_pretrained",
             side_effect=ValueError("Unrecognized model_type foo"),
         ):
-            with self.assertRaises(ValueError) as ctx:
+            with self.assertRaises(UnsupportedArchitectureError) as ctx:
                 select_model("someuser/mystery-model")
-        # Not-found / unrecognized configs surface a clear message rather than a
-        # generic crash.
         self.assertIn("PyTorch models only", str(ctx.exception))
+
+
+class TestTypedConfigErrors(unittest.TestCase):
+    """Each upstream HuggingFace failure maps to a typed ModelSelectionError."""
+
+    MODEL = "someuser/mystery-model"
+
+    def test_each_upstream_exception_maps_to_typed_error(self):
+        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+
+        cases = [
+            (
+                RepositoryNotFoundError("404 Client Error", response=None),
+                ModelNotFoundError,
+                "not found",
+            ),
+            (
+                GatedRepoError("403 gated", response=None),
+                GatedModelError,
+                "gated",
+            ),
+            (
+                OSError("Connection reset by peer"),
+                ModelEnvironmentError,
+                "network",
+            ),
+            (
+                ValueError(
+                    "Loading someuser/mystery-model requires you to execute the "
+                    "configuration file in that repo. Pass `trust_remote_code=True`."
+                ),
+                RemoteCodeRequiredError,
+                "trust_remote_code",
+            ),
+            (
+                ValueError("Unrecognized model_type foo"),
+                UnsupportedArchitectureError,
+                "PyTorch models only",
+            ),
+        ]
+        for upstream, expected_cls, msg_fragment in cases:
+            with self.subTest(expected=expected_cls.__name__):
+                with patch(
+                    "transformers.AutoConfig.from_pretrained",
+                    side_effect=upstream,
+                ):
+                    with self.assertRaises(expected_cls) as ctx:
+                        select_model(self.MODEL)
+                self.assertIn(msg_fragment.lower(), str(ctx.exception).lower())
+
+    def test_esmc_unrecognized_model_type_raises_fork_error(self):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=ValueError("Unrecognized model_type esmc"),
+        ):
+            with self.assertRaises(ESMCForkRequiredError) as ctx:
+                select_model("biohub/ESMC-300M")
+        self.assertIn("Biohub/transformers", str(ctx.exception))
+
+    def test_gated_esmc_raises_fork_error(self):
+        from huggingface_hub.errors import GatedRepoError
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=GatedRepoError("403 gated", response=None),
+        ):
+            with self.assertRaises(ESMCForkRequiredError) as ctx:
+                select_model("biohub/ESMC-300M")
+        self.assertIn("Biohub/transformers", str(ctx.exception))
+
+    def test_trust_remote_code_skips_remote_code_error_when_flag_set(self):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=ValueError(
+                "Pass `trust_remote_code=True` to load this model."
+            ),
+        ):
+            with self.assertRaises(ModelSelectionError):
+                select_model(self.MODEL, trust_remote_code=True)
 
 
 class TestBareWeightNames(unittest.TestCase):
@@ -98,6 +185,95 @@ class TestBareWeightNames(unittest.TestCase):
     def test_unsupported_bare_name_raises(self):
         with self.assertRaises(ValueError):
             select_model("not-a-real-model")
+
+
+class TestTrustRemoteCode(unittest.TestCase):
+    def test_select_model_forwards_trust_remote_code_to_autoconfig(self):
+        with patch("transformers.AutoConfig.from_pretrained") as mock_config:
+            mock_config.return_value = _config("bert")
+            select_model("someuser/model-x", trust_remote_code=True)
+        mock_config.assert_called_once_with(
+            "someuser/model-x", trust_remote_code=True
+        )
+
+    def test_generic_embedder_passes_trust_remote_code_to_from_pretrained(self):
+        import torch
+        from pepe.embedders.huggingface_embedder import GenericHuggingFaceEmbedder
+
+        recorded = {"tokenizer": None, "model": None}
+
+        def tok_from_pretrained(link, **kwargs):
+            recorded["tokenizer"] = kwargs
+            mock = MagicMock()
+            mock.pad_token = "<pad>"
+            mock.all_special_ids = [0]
+            return mock
+
+        def model_from_pretrained(link, **kwargs):
+            recorded["model"] = kwargs
+            mock = MagicMock()
+            mock.config = MagicMock(
+                num_attention_heads=4,
+                num_hidden_layers=2,
+                hidden_size=32,
+            )
+            mock.to.return_value = mock
+            mock.eval.return_value = None
+            return mock
+
+        embedder = GenericHuggingFaceEmbedder.__new__(GenericHuggingFaceEmbedder)
+        embedder.trust_remote_code = True
+        embedder.return_contacts = False
+        embedder.device = torch.device("cpu")
+
+        with patch(
+            "pepe.embedders.huggingface_embedder._import_transformers",
+            return_value=(None,) * 5
+            + (
+                MagicMock(from_pretrained=model_from_pretrained),
+                MagicMock(from_pretrained=tok_from_pretrained),
+                MagicMock(from_pretrained=model_from_pretrained),
+                MagicMock(from_pretrained=model_from_pretrained),
+            ),
+        ):
+            embedder._initialize_model("lab/custom-model")
+
+        self.assertEqual(
+            recorded["tokenizer"], {"use_fast": True, "trust_remote_code": True}
+        )
+        self.assertTrue(recorded["model"]["trust_remote_code"])
+
+
+class TestReportModel(unittest.TestCase):
+    def test_report_names_embedder_and_flags_subword_tokenizer(self):
+        mock_config = MagicMock()
+        mock_config.model_type = "bert"
+        mock_config.max_position_embeddings = 512
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.model_max_length = 512
+        mock_tokenizer.encode.return_value = [1, 2, 3]
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_config
+        ), patch(
+            "transformers.AutoTokenizer.from_pretrained", return_value=mock_tokenizer
+        ), patch(
+            "pepe.model_selecter.select_model",
+            return_value=MagicMock(__name__="GenericHuggingFaceEmbedder"),
+        ), patch(
+            "pepe.utils.is_character_tokenizer", return_value=False
+        ):
+            buf = StringIO()
+            with patch("sys.stdout", buf):
+                report_model("someuser/protbert", trust_remote_code=True)
+
+        output = buf.getvalue()
+        self.assertIn("Architecture:    bert", output)
+        self.assertIn("Embedder:        GenericHuggingFaceEmbedder", output)
+        self.assertIn("Max length:      512", output)
+        self.assertIn("subword", output)
+        self.assertIn("Logits:          no", output)
 
 
 if __name__ == "__main__":

--- a/src/tests/test_model_selection.py
+++ b/src/tests/test_model_selection.py
@@ -24,6 +24,13 @@ def _config(model_type):
     return cfg
 
 
+def _mock_hf_response():
+    """huggingface_hub >=1.0 requires a response with headers."""
+    response = MagicMock()
+    response.headers = {}
+    return response
+
+
 class TestHuggingFaceDispatch(unittest.TestCase):
     """Config-first dispatch for HuggingFace repo ids (username/model-name)."""
 
@@ -91,12 +98,14 @@ class TestTypedConfigErrors(unittest.TestCase):
 
         cases = [
             (
-                RepositoryNotFoundError("404 Client Error", response=None),
+                RepositoryNotFoundError(
+                    "404 Client Error", response=_mock_hf_response()
+                ),
                 ModelNotFoundError,
                 "not found",
             ),
             (
-                GatedRepoError("403 gated", response=None),
+                GatedRepoError("403 gated", response=_mock_hf_response()),
                 GatedModelError,
                 "gated",
             ),
@@ -143,7 +152,7 @@ class TestTypedConfigErrors(unittest.TestCase):
 
         with patch(
             "transformers.AutoConfig.from_pretrained",
-            side_effect=GatedRepoError("403 gated", response=None),
+            side_effect=GatedRepoError("403 gated", response=_mock_hf_response()),
         ):
             with self.assertRaises(ESMCForkRequiredError) as ctx:
                 select_model("biohub/ESMC-300M")


### PR DESCRIPTION
## Summary
- Align `GenericHuggingFaceEmbedder` with ESM-2 safeguards (attention/output handling, safer forward path).
- Add opt-in `--trust_remote_code` and `--check_model` preflight; map load/compat failures to typed errors in `model_errors.py`.
- Extend model selection/dispatch and CLI/API wiring; update CI workflow for gated unit tests and tiny-BERT integration tests.

## Test plan
- [ ] `python -m pytest src/tests/test_generic_safeguards.py src/tests/test_model_selection.py -q`
- [ ] `python -m pytest src/tests/test_generic_hf_integration.py -q` (requires network/HF cache as in CI)
- [ ] Smoke: `pepe --check_model --model_name <hf-id> --fasta_path src/tests/test_files/single_seq.fasta --extract_embeddings mean_pooled`
- [ ] Confirm GitHub Actions `test` workflow passes on this branch


Made with [Cursor](https://cursor.com)