### PR TITLE
Fix streaming attention data loss and improve embedding reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,51 @@ truth that drives publishing).
 - `pepe --check_model <repo>` dry-run that loads config and tokenizer only and
   prints architecture, embedder choice, max length, tokenizer type, and output
   capabilities before any embedding run.
+- `--verbose` CLI/API flag to enable GPU/IO profiling stats at the end of an
+  embedding run (default off).
+- Streaming vs in-memory regression tests (`test_streaming_roundtrip.py`)
+  covering all standard output types.
+- Session-scoped pytest fixture that loads ESM2-8M once per test session;
+  `@pytest.mark.integration` and `@pytest.mark.slow` markers registered in
+  `conftest.py`.
+
+### Changed
+- Logger namespace unified under `pepe` (was `src.*`) so API and module loggers
+  share handlers.
+- HuggingFace dataset tokenization batches all sequences in one tokenizer call
+  instead of a per-sequence loop.
+- Per-batch `gc.collect()` and non-OOM `torch.cuda.empty_cache()` removed from
+  the embed loop (CUDA cache is still cleared on OOM retry paths).
+- GPU/IO profiling summary is logged only when `--verbose` is set.
+- HuggingFace config/load failures are classified by upstream exception type
+  instead of string-sniffing on error messages (`model_errors.py`).
+- Generic HuggingFace model loading no longer auto-enables `trust_remote_code`
+  based on repo name patterns; use `--trust_remote_code` explicitly when needed.
+
+### Fixed
+- Streaming mode silently dropped attention outputs due to memmap registry key
+  mismatches (`attention_matrices_*` vs `attention_head` / `attention_layer` /
+  `attention_model`).
+- `preallocate_disk_space()` failed for model-level outputs such as
+  `attention_model` when assigning memmaps via `setattr` on a dict.
+- `get_substring_positions` did not raise when a CSV substring entry was missing
+  for a sequence label.
+- Substring pooling produced NaN embeddings when a substring did not match the
+  tokenized full sequence; now raises `ValueError` with the sequence label.
+- Missing substring CSV entries raised a generic `assert` (disabled under
+  `python -O`); replaced with `ValueError` listing missing IDs.
+- `MultiIODispatcher` default `heavy_output_type` updated from legacy
+  `embeddings_unpooled` to `per_token`.
+- Generic HuggingFace embedder (`GenericHuggingFaceEmbedder`) now mirrors ESM-2
+  safeguards: length-limit detection and optional sequence splitting via
+  `_check_max_input_length`, eager attention when extracting contacts, and a
+  warning when the tokenizer is subword-based (per-residue outputs may be
+  misaligned). Sentinel `tokenizer.model_max_length` values (~1e30) are treated
+  as unknown limits instead of a real cap.
+
+## [1.3.0] - 2026-07-07
+
+### Added
 - Broader model compatibility: BERT-like and other unrecognized HuggingFace
   architectures now fall back to the generic `AutoModel`-based embedder instead
   of raising, so standard protein encoders such as ProtBert, AntiBERTy and
@@ -45,10 +90,6 @@ truth that drives publishing).
   installed it manually; CI now guards against this regression.
 
 ### Changed
-- HuggingFace config/load failures are classified by upstream exception type
-  instead of string-sniffing on error messages (`model_errors.py`).
-- Generic HuggingFace model loading no longer auto-enables `trust_remote_code`
-  based on repo name patterns; use `--trust_remote_code` explicitly when needed.
 - Model dispatch (`model_selecter.py`) now inspects a HuggingFace repo's config
   (`AutoConfig.model_type`) before matching on its name. A fine-tune whose repo
   slug contains "esm2" but whose architecture is something else is no longer
@@ -61,12 +102,6 @@ truth that drives publishing).
   `pypa/gh-action-pypi-publish` is Docker-based and unaffected.
 
 ### Fixed
-- Generic HuggingFace embedder (`GenericHuggingFaceEmbedder`) now mirrors ESM-2
-  safeguards: length-limit detection and optional sequence splitting via
-  `_check_max_input_length`, eager attention when extracting contacts, and a
-  warning when the tokenizer is subword-based (per-residue outputs may be
-  misaligned). Sentinel `tokenizer.model_max_length` values (~1e30) are treated
-  as unknown limits instead of a real cap.
 - Corrected the PyPI license classifier from "GNU Affero General Public License
   v3" to "MIT License" in `pyproject.toml` and `setup.py`, matching the actual
   `LICENSE` file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ PEPE (Pipeline for Easy Protein Embedding) is a CLI + Python library that extrac
 
 ## Source layout
 
-The real package lives in `src/pepe/`. The repo root also contains untracked `pepe-cli/` and `pepe-cli-1/` directories that are stray full copies of the project — **ignore them; do all work under `src/`.**
+The real package lives in `src/pepe/`.
 
 ## Commands
 
@@ -31,8 +31,6 @@ python -m pytest src/tests/
 python -m pytest src/tests/test_api_unittest.py            # single file
 python -m pytest src/tests/test_api_unittest.py::TestPepeAPI::test_embed_to_disk   # single test
 ```
-
-Note: `src/tests/test_run.py` and `test_run.sh` are stale (they use removed args like `--batch_writing` and an old constructor signature); don't treat them as the test entry point.
 
 ## Version / release flow
 

--- a/src/pepe/__init__.py
+++ b/src/pepe/__init__.py
@@ -16,7 +16,7 @@ __description__ = "Pipeline for Easy Protein Embedding - Extract embeddings and 
 __homepage__ = "https://github.com/csi-greifflab/pepe-cli"
 
 
-# Configure logging for the embedairr package
+# Configure logging for the pepe package
 def setup_logging(level=logging.INFO):
     """Set up logging configuration for the PEPE package."""
     # Create formatter
@@ -30,7 +30,7 @@ def setup_logging(level=logging.INFO):
     console_handler.setFormatter(formatter)
 
     # Get root logger for the package
-    logger = logging.getLogger("src")
+    logger = logging.getLogger("pepe")
     logger.setLevel(level)
 
     # Remove existing handlers to avoid duplication

--- a/src/pepe/__main__.py
+++ b/src/pepe/__main__.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from pepe.parse_arguments import parse_arguments
 
-logger = logging.getLogger("src.__main__")
+logger = logging.getLogger("pepe.__main__")
 
 
 def main():

--- a/src/pepe/api.py
+++ b/src/pepe/api.py
@@ -95,6 +95,7 @@ def embed(
         "disable_special_tokens": kwargs.get("disable_special_tokens", False),
         "flatten": kwargs.get("flatten", False),
         "flush_batches_after": kwargs.get("flush_batches_after", 128),
+        "verbose": kwargs.get("verbose", False),
     }
     
     args = SimpleNamespace(**args_dict)

--- a/src/pepe/embedders/base_embedder.py
+++ b/src/pepe/embedders/base_embedder.py
@@ -5,14 +5,13 @@ import re
 import numpy as np
 from numpy.lib.format import open_memmap
 import inspect
-import gc
 from pepe.utils import MultiIODispatcher, check_disk_free_space
 from alive_progress import alive_bar
 import time
 from pathlib import Path
 import logging
 
-logger = logging.getLogger("src.embedders.base_embedder")
+logger = logging.getLogger("pepe.embedders.base_embedder")
 
 
 class BaseEmbedder:
@@ -89,6 +88,7 @@ class BaseEmbedder:
         self.flush_batches_after = args.flush_batches_after * 1024**2  # in bytes
         self.precision = args.precision
         # self.log_memory = args.log_memory # TODO implement memory logging
+        self.verbose = getattr(args, "verbose", False)
         self.total_gpu_time = 0.0
         self.total_backpressure_time = 0.0
         self.total_io_enqueue_time = 0.0
@@ -281,7 +281,7 @@ class BaseEmbedder:
                 output_array = open_memmap(
                     file_path, mode=mode, dtype=np_dtype, shape=shape
                 )
-                setattr(getattr(self, output_type), "output_data", output_array)
+                getattr(self, output_type)["output_data"] = output_array
                 memmap_registry[(output_type, None, None)] = output_array
                 total_bytes += bytes_per_array
 
@@ -385,7 +385,6 @@ class BaseEmbedder:
                 logits, representations, attention_matrices = self._safe_compute(
                     toks, attention_mask
                 )
-                torch.cuda.empty_cache()
                 self.total_gpu_time += time.time() - t0_gpu
                 
                 output_bundle = {
@@ -417,8 +416,6 @@ class BaseEmbedder:
                 self.total_io_enqueue_time += time.time() - t0_io
 
                 del logits, representations, attention_matrices
-                gc.collect()
-                torch.cuda.empty_cache()
 
                 offset += len(toks)
 
@@ -432,13 +429,20 @@ class BaseEmbedder:
                 self.io_dispatcher.stop()
 
             logger.info("Finished extracting embeddings")
-            logger.info(f"--- Profiling Results ---")
-            logger.info(f"Total GPU compute time: {self.total_gpu_time:.2f}s")
-            logger.info(f"Total Backpressure wait time: {self.total_backpressure_time:.2f}s")
-            logger.info(f"Total IO Enqueue time: {self.total_io_enqueue_time:.2f}s")
-            if self.total_gpu_time > 0:
-                overhead = (self.total_backpressure_time + self.total_io_enqueue_time) / self.total_gpu_time
-                logger.info(f"IO Overhead ratio: {overhead:.2f}x")
+            if self.verbose:
+                logger.info("--- Profiling Results ---")
+                logger.info(f"Total GPU compute time: {self.total_gpu_time:.2f}s")
+                logger.info(
+                    f"Total Backpressure wait time: {self.total_backpressure_time:.2f}s"
+                )
+                logger.info(
+                    f"Total IO Enqueue time: {self.total_io_enqueue_time:.2f}s"
+                )
+                if self.total_gpu_time > 0:
+                    overhead = (
+                        self.total_backpressure_time + self.total_io_enqueue_time
+                    ) / self.total_gpu_time
+                    logger.info(f"IO Overhead ratio: {overhead:.2f}x")
 
         # After successful completion, clean up the checkpoint file
         if self.streaming_output:
@@ -480,7 +484,7 @@ class BaseEmbedder:
         try:
             substring = self.substring_dict[label]  # type: ignore
         except KeyError:
-            SystemExit(f"No matching substring found for {label}")
+            raise SystemExit(f"No matching substring found for {label}")
         # remove '-' from substring
         substring = substring.replace("-", "")
 
@@ -508,7 +512,6 @@ class BaseEmbedder:
         # clear the output bundle to free up memory
         output_bundle.clear()
         del output_bundle
-        torch.cuda.empty_cache()
 
     def _mask_special_tokens(self, input_tensor, special_tokens=None):
         """
@@ -644,7 +647,7 @@ class BaseEmbedder:
                     # ][head]
                     # self.write_batch_to_disk(output_file, tensor, offset)
                     self.io_dispatcher.enqueue(
-                        output_type="attention_matrices_all_heads",
+                        output_type="attention_head",
                         layer=layer,
                         head=head,
                         offset=offset,
@@ -678,7 +681,7 @@ class BaseEmbedder:
                 # ]
                 # self.write_batch_to_disk(output_file, tensor, offset)
                 self.io_dispatcher.enqueue(
-                    output_type="attention_matrices_average_layers",
+                    output_type="attention_layer",
                     layer=layer,
                     head=None,
                     offset=offset,
@@ -707,7 +710,7 @@ class BaseEmbedder:
             # output_file = self.attention_matrices_average_all["output_data"]
             # self.write_batch_to_disk(output_file, tensor, offset)
             self.io_dispatcher.enqueue(
-                output_type="attention_matrices_average_all",
+                output_type="attention_model",
                 layer=None,
                 head=None,
                 offset=offset,

--- a/src/pepe/embedders/custom_embedder.py
+++ b/src/pepe/embedders/custom_embedder.py
@@ -8,7 +8,7 @@ import pepe.utils
 from pepe.embedders.base_embedder import BaseEmbedder
 from transformers import AutoTokenizer
 
-logger = logging.getLogger("src.embedders.custom_embedder")
+logger = logging.getLogger("pepe.embedders.custom_embedder")
 
 
 class CustomEmbedder(BaseEmbedder):

--- a/src/pepe/embedders/esm_embedder.py
+++ b/src/pepe/embedders/esm_embedder.py
@@ -18,7 +18,7 @@ def _import_esm():
         ) from e
 
 
-logger = logging.getLogger("src.embedders.esm_embedder")
+logger = logging.getLogger("pepe.embedders.esm_embedder")
 
 
 class ESMEmbedder(BaseEmbedder):

--- a/src/pepe/embedders/huggingface_embedder.py
+++ b/src/pepe/embedders/huggingface_embedder.py
@@ -38,7 +38,7 @@ def _import_transformers():
 # Set max_split_size_mb
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:128"
 
-logger = logging.getLogger("src.embedders.huggingface_embedder")
+logger = logging.getLogger("pepe.embedders.huggingface_embedder")
 
 
 class HuggingfaceEmbedder(BaseEmbedder):

--- a/src/pepe/model_selecter.py
+++ b/src/pepe/model_selecter.py
@@ -112,7 +112,7 @@ def _select_hf_model(model_name, trust_remote_code=False):
     # instead of raising.
     import logging
 
-    logging.getLogger("src.model_selecter").info(
+    logging.getLogger("pepe.model_selecter").info(
         f"No specialized embedder for architecture '{model_type or 'unknown'}'; "
         f"using the generic HuggingFace embedder for {model_name}."
     )

--- a/src/pepe/parse_arguments.py
+++ b/src/pepe/parse_arguments.py
@@ -188,6 +188,11 @@ def parse_arguments():
         help="Precision of the output data. Inference during embedding is not affected. Default is 'float32'.",
     )
     parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output including GPU/IO profiling stats. Default is False.",
+    )
+    parser.add_argument(
         "--device",
         type=str.lower,
         default="cuda",

--- a/src/pepe/utils.py
+++ b/src/pepe/utils.py
@@ -12,7 +12,7 @@ import threading, queue
 from alive_progress import alive_bar
 import shutil
 
-logger = logging.getLogger("src.utils")
+logger = logging.getLogger("pepe.utils")
 
 
 class TokenBudgetBatchSampler:
@@ -82,9 +82,12 @@ class SequenceDictDataset(Dataset):
         filtered_substring_dict = {
             label: self.substring_dict[label] for label in labels if label in self.substring_dict  # type: ignore
         }
-        assert len(filtered_substring_dict) == len(
-            self.data
-        ), "Not all sequences have matching substrings."
+        if len(filtered_substring_dict) != len(self.data):
+            missing = [label for label in labels if label not in self.substring_dict]  # type: ignore
+            raise ValueError(
+                "Not all sequences have matching substrings. "
+                f"Missing substring entries for: {', '.join(missing)}"
+            )
         return filtered_substring_dict.items()
 
     def _get_substring_masks(self):
@@ -94,12 +97,18 @@ class SequenceDictDataset(Dataset):
         substring_tokens = [entry[2] for entry in self.encoded_substring_data]  # type: ignore
 
         # Create masks for each sequence
-        masks = [
-            self._find_subsequence(full_seq, substring, self.pad_token_id)  # type: ignore
-            for full_seq, substring in zip(full_sequence_tokens, substring_tokens)
-        ]
+        masks = []
+        for (label, _, _), full_seq, substring in zip(
+            self.encoded_data, full_sequence_tokens, substring_tokens  # type: ignore
+        ):
+            mask = self._find_subsequence(full_seq, substring, self.pad_token_id)  # type: ignore
+            if mask.sum() == 0:
+                raise ValueError(
+                    f"Substring for sequence '{label}' not found in the tokenized full sequence."
+                )
+            masks.append(mask)
 
-        return list(masks)
+        return masks
 
     def _find_subsequence(self, full_tensor, subtensor, pad_token_id=0):
         subsequence_mask = torch.zeros_like(full_tensor)
@@ -194,22 +203,17 @@ class HuggingFaceDataset(SequenceDictDataset):
                 max_length = max_token_length
         loop_input_ids = []
         loop_attention_mask = []
-        with alive_bar(len(strs), title="Tokenizing sequences...") as bar:
-            for s in strs:
-                out = tokenizer(
-                    s,
-                    truncation=True,
-                    padding="max_length",
-                    max_length=max_length,
-                    add_special_tokens=add_special_tokens,
-                    return_tensors="pt",
-                )
-                loop_input_ids.append(out.input_ids)
-                loop_attention_mask.append(out.attention_mask)
-                bar()
-
-        toks = torch.cat(loop_input_ids, dim=0)
-        attention_masks = torch.cat(loop_attention_mask, dim=0)
+        logger.info(f"Tokenizing {len(strs)} sequences...")
+        out = tokenizer(
+            list(strs),
+            truncation=True,
+            padding="max_length",
+            max_length=max_length,
+            add_special_tokens=add_special_tokens,
+            return_tensors="pt",
+        )
+        toks = out.input_ids
+        attention_masks = out.attention_mask
         return list(zip(labels, strs, list(toks), list(attention_masks)))
 
     def get_max_encoded_length(self):
@@ -855,7 +859,7 @@ class MultiIODispatcher:
         memmap_registry,
         num_workers=4,
         flush_bytes_limit=64 * 1024 * 1024,
-        heavy_output_type="embeddings_unpooled",
+        heavy_output_type="per_token",
         heavy_proportion=0.75,
         checkpoint_dir=None,
     ):

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Shared pytest fixtures for PEPE tests."""
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.abspath("src"))
+
+ESM2_MODEL_NAME = "esm2_t6_8M_UR50D"
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "integration: tests that download/load real models"
+    )
+    config.addinivalue_line("markers", "slow: tests that take significant time")
+
+
+@pytest.fixture(scope="session")
+def esm2_model_cache():
+    """Load ESM2-8M once per session and patch embedder to reuse it."""
+    from pepe.embedders.huggingface_embedder import (
+        ESM2Embedder,
+        _import_transformers,
+        _resolve_esm2_model_link,
+    )
+
+    model_link = _resolve_esm2_model_link(ESM2_MODEL_NAME)
+    device = torch.device("cpu")
+
+    (
+        _T5EncoderModel,
+        _T5Tokenizer,
+        _RoFormerTokenizer,
+        _RoFormerModel,
+        _RoFormerSinusoidalPositionalEmbedding,
+        _AutoModel,
+        AutoTokenizer,
+        _AutoModelForCausalLM,
+        AutoModelForMaskedLM,
+    ) = _import_transformers()
+
+    tokenizer = AutoTokenizer.from_pretrained(model_link)
+    # MaskedLM + eager attention covers logits, attention, and embedding outputs.
+    model = AutoModelForMaskedLM.from_pretrained(
+        model_link, attn_implementation="eager"
+    ).to(device)
+    model.eval()
+
+    config = model.config
+    bundle = {
+        "model": model,
+        "tokenizer": tokenizer,
+        "num_heads": config.num_attention_heads,
+        "num_layers": config.num_hidden_layers,
+        "embedding_size": config.hidden_size,
+    }
+
+    original = ESM2Embedder._initialize_model
+
+    def _cached_initialize(self, model_name):
+        return (
+            bundle["model"],
+            bundle["tokenizer"],
+            bundle["num_heads"],
+            bundle["num_layers"],
+            bundle["embedding_size"],
+        )
+
+    ESM2Embedder._initialize_model = _cached_initialize
+    yield bundle
+    ESM2Embedder._initialize_model = original

--- a/src/tests/test_api_unittest.py
+++ b/src/tests/test_api_unittest.py
@@ -5,11 +5,18 @@ import shutil
 import tempfile
 import numpy as np
 import torch
+import pytest
 
 # Add src to sys.path
 sys.path.insert(0, os.path.abspath("src"))
 
 import pepe
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.usefixtures("esm2_model_cache"),
+]
 
 class TestPepeAPI(unittest.TestCase):
     @classmethod

--- a/src/tests/test_generic_safeguards.py
+++ b/src/tests/test_generic_safeguards.py
@@ -104,7 +104,7 @@ class TestGenericLengthSafety(unittest.TestCase):
         self.assertGreater(len(embedder.chunks_mapping["long_prot"]), 1)
 
     def test_warns_when_split_long_sequences_disabled(self):
-        with self.assertLogs("src.embedders.base_embedder", level="WARNING") as logs:
+        with self.assertLogs("pepe.embedders.base_embedder", level="WARNING") as logs:
             self._build_embedder(split_long_sequences=False)
         self.assertTrue(
             any("exceed the model's maximum allowed length" in msg for msg in logs.output)
@@ -204,13 +204,13 @@ class TestCharacterTokenizerDetection(unittest.TestCase):
 
     def test_subword_tokenizer_logs_warning(self):
         _, tokenizer = _mock_model_tokenizer(char_level=False)
-        with self.assertLogs("src.utils", level="WARNING") as logs:
+        with self.assertLogs("pepe.utils", level="WARNING") as logs:
             warn_if_non_character_tokenizer(tokenizer, "someuser/wordpiece-bert")
         self.assertTrue(any("subword tokenizer" in msg for msg in logs.output))
 
     def test_char_level_tokenizer_no_warning(self):
         _, tokenizer = _mock_model_tokenizer(char_level=True)
-        with patch.object(logging.getLogger("src.utils"), "warning") as mock_warn:
+        with patch.object(logging.getLogger("pepe.utils"), "warning") as mock_warn:
             warn_if_non_character_tokenizer(tokenizer, "someuser/char-bert")
         mock_warn.assert_not_called()
 
@@ -224,7 +224,7 @@ class TestSentinelModelMaxLength(unittest.TestCase):
         embedder.tokenizer = MagicMock()
         embedder.tokenizer.model_max_length = 1000000000000.0
 
-        with self.assertLogs("src.embedders.base_embedder", level="INFO") as logs:
+        with self.assertLogs("pepe.embedders.base_embedder", level="INFO") as logs:
             result = embedder._get_model_max_allowed()
 
         self.assertIsNone(result)

--- a/src/tests/test_splitting.py
+++ b/src/tests/test_splitting.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 import torch
 import numpy as np
-from Bio import SeqIO
 import subprocess
 import shutil
 

--- a/src/tests/test_streaming_roundtrip.py
+++ b/src/tests/test_streaming_roundtrip.py
@@ -1,0 +1,143 @@
+"""Regression tests: streaming disk output must match in-memory results."""
+import glob
+import os
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.abspath("src"))
+
+import pepe
+from pepe.embedders.base_embedder import BaseEmbedder
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.usefixtures("esm2_model_cache"),
+]
+
+MODEL_NAME = "esm2_t6_8M_UR50D"
+LAYER = 6
+NUM_HEADS = 8
+EXPERIMENT_NAME = "roundtrip"
+
+SHORT_SEQUENCES = {
+    "seq1": (
+        "MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHGKKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLLSHCLLVTLAAHLPAEFTPAVHASLDKFLASVSTVLTSKYR"
+    ),
+    "seq2": (
+        "MNIFEMLRIDEGLRLKIYKDTEGYYTIGIGHLLTKSPSLNAAKSELDKAIGRNCNGVITKDEAEKLFNQDVDAAVRGILRNAKLKPVYDSLDAVRRAALINMVFQMGETGVAGFTNSLRMLQQKRWDEAAVNLAKSRWYNQTPNRAKRVITTFRTGTWDAYK"
+    ),
+}
+
+OUTPUT_TYPES = [
+    "mean_pooled",
+    "per_token",
+    "attention_head",
+    "attention_layer",
+    "attention_model",
+    "logits",
+]
+
+
+def _stack_tensors(items):
+    if isinstance(items[0], torch.Tensor):
+        return torch.stack(items).numpy()
+    return np.stack(items)
+
+
+def in_memory_to_numpy(output_data, output_type, layer=LAYER, num_heads=NUM_HEADS):
+    if output_type == "attention_model":
+        return _stack_tensors(output_data)
+    if output_type == "attention_head":
+        return {
+            head: _stack_tensors(output_data[layer][head])
+            for head in range(num_heads)
+        }
+    return _stack_tensors(output_data[layer])
+
+
+def _output_dir(output_path, output_type):
+    return os.path.join(output_path, MODEL_NAME, output_type)
+
+
+def load_streaming_array(output_path, output_type, layer=LAYER, head=None):
+    output_dir = _output_dir(output_path, output_type)
+    if output_type == "attention_model":
+        pattern = os.path.join(output_dir, f"{EXPERIMENT_NAME}_{MODEL_NAME}_attention_model.npy")
+        files = [pattern] if os.path.exists(pattern) else glob.glob(os.path.join(output_dir, "*.npy"))
+    elif output_type == "attention_head":
+        pattern = os.path.join(
+            output_dir,
+            f"{EXPERIMENT_NAME}_{MODEL_NAME}_attention_head_layer_{layer}_head_{head + 1}.npy",
+        )
+        files = [pattern] if os.path.exists(pattern) else glob.glob(
+            os.path.join(output_dir, f"*_layer_{layer}_head_{head + 1}.npy")
+        )
+    else:
+        pattern = os.path.join(
+            output_dir,
+            f"{EXPERIMENT_NAME}_{MODEL_NAME}_{output_type}_layer_{layer}.npy",
+        )
+        files = [pattern] if os.path.exists(pattern) else glob.glob(
+            os.path.join(output_dir, f"*_{output_type}_layer_{layer}.npy")
+        )
+    assert len(files) == 1, f"Expected one file for {output_type}, found {files}"
+    return np.load(files[0])
+
+
+def load_streaming_output(output_path, output_type, layer=LAYER, num_heads=NUM_HEADS):
+    if output_type == "attention_head":
+        return {
+            head: load_streaming_array(output_path, output_type, layer, head)
+            for head in range(num_heads)
+        }
+    return load_streaming_array(output_path, output_type, layer)
+
+
+def _assert_allclose(reference, streaming, output_type):
+    if output_type == "attention_head":
+        for head in reference:
+            np.testing.assert_allclose(
+                reference[head], streaming[head], rtol=1e-4, atol=1e-4
+            )
+            assert np.any(streaming[head] != 0), f"{output_type} head {head} is all zeros"
+    else:
+        np.testing.assert_allclose(reference, streaming, rtol=1e-4, atol=1e-4)
+        assert np.any(streaming != 0), f"{output_type} is all zeros"
+
+
+def test_streaming_matches_in_memory(tmp_path):
+    common_kwargs = {
+        "model_name": MODEL_NAME,
+        "sequences": SHORT_SEQUENCES,
+        "extract_embeddings": OUTPUT_TYPES,
+        "device": "cpu",
+        "experiment_name": EXPERIMENT_NAME,
+        "layers": [[-1]],
+    }
+
+    in_memory = pepe.embed(streaming_output=False, **common_kwargs)
+    for output_type in OUTPUT_TYPES:
+        assert output_type in in_memory
+
+    pepe.embed(
+        streaming_output=True,
+        output_path=str(tmp_path),
+        **common_kwargs,
+    )
+
+    for output_type in OUTPUT_TYPES:
+        reference = in_memory_to_numpy(in_memory[output_type], output_type)
+        streaming = load_streaming_output(str(tmp_path), output_type)
+        _assert_allclose(reference, streaming, output_type)
+
+
+def test_get_substring_positions_missing_raises():
+    embedder = object.__new__(BaseEmbedder)
+    embedder.sequences = {"seq1": "ACDEFG"}
+    embedder.substring_dict = {}
+    with pytest.raises(SystemExit, match="No matching substring found for seq1"):
+        embedder.get_substring_positions("seq1", special_tokens=1)


### PR DESCRIPTION
## Summary
- Fix streaming mode silently dropping attention outputs due to memmap registry key mismatches, and fix `preallocate_disk_space()` for model-level outputs like `attention_model`.
- Harden substring pooling: fail fast with clear `ValueError`s when CSV entries are missing or substrings do not match tokenized sequences; fix missing `raise` in `get_substring_positions`.
- Add `--verbose` flag for GPU/IO profiling, unify logging under the `pepe` namespace, batch HuggingFace tokenization, and remove per-batch GC overhead.
- Add streaming round-trip regression tests and a session-scoped ESM2 fixture to speed up integration tests (~13 min → ~3 s for the targeted suite).

## Test plan
- [x] `python -m pytest src/tests/test_streaming_roundtrip.py src/tests/test_api_unittest.py -v` (8 passed)
- [x] Full suite: 59 passed, 6 skipped
- [ ] CI on `test` branch (TestPyPI publish workflow)


Made with [Cursor](https://cursor.com)