### PR TITLE
Refresh README and bump artifact actions to Node 24

### DIFF
--- a/.github/workflows/publish-main-branch-trusted.yml
+++ b/.github/workflows/publish-main-branch-trusted.yml
@@ -134,7 +134,7 @@ jobs:
         echo "Package $PACKAGE_NAME version $CURRENT_VERSION is now available on PyPI!"
 
     - name: Upload dist artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: dist-packages
         path: dist/
@@ -279,7 +279,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist-packages
           path: dist/

--- a/README.md
+++ b/README.md
@@ -1,85 +1,120 @@
 # PEPE
 
-PEPE (Pipeline for Easy Protein Embedding) is a tool for extracting embeddings and attention matrices from protein sequences using pre-trained models. This tool supports various configurations for extracting embeddings and attention matrices, including options for handling CDR3 sequences. Currently implemented models are ESM2 from the 2023 paper ["Evolutionary-scale prediction of atomic-level protein structure with a language model"](https://science.org/doi/10.1126/science.ade2574) and AntiBERTa2-CSSP from the 2023 conference paper ["Enhancing Antibody Language Models with Structural Information"](https://www.mlsb.io/papers_2023/Enhancing_Antibody_Language_Models_with_Structural_Information.pdf). PEPE also supports custom PLMs from local files or from Huggingface Hub addresses.
+**Parallel Extraction for Protein Embeddings**
 
-### Citation
-> **PEPE: Scalable extraction of multi-modal protein language model representations**
-> Jahn Zhong, Niccolò Cardente, Geir Kjetil Sandve, Habib Bashour, Maria Francesca Abbate, Victor Greiff
-> *bioRxiv* (2026)
-> [DOI: 10.1101/2025.10.13.680902](https://doi.org/10.1101/2025.10.13.680902)
+[![PyPI](https://img.shields.io/pypi/v/pepe-cli)](https://pypi.org/project/pepe-cli/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/csi-greifflab/pepe-cli/blob/main/LICENSE)
+[![DOI](https://img.shields.io/badge/DOI-10.1093%2Fbioinformatics%2Fbtag375-blue)](https://doi.org/10.1093/bioinformatics/btag375)
+[![Zenodo](https://img.shields.io/badge/Zenodo-15912054-blue)](https://zenodo.org/records/15912054)
 
-## Quick start
+PEPE is a **command-line tool and Python library** for high-throughput, multi-modal extraction of representations from protein language models (PLMs). It extracts embeddings and attention matrices from protein sequences in a single parallelized, streaming pass — letting you build embedding datasets that are limited only by the write speed and capacity of your storage, not by available RAM.
 
-1. Install PEPE
+PEPE supports ESM-1, ESM-2, ProtT5, ProstT5, and AntiBERTa2 out of the box, along with any compatible model from the Hugging Face Hub and custom local PyTorch models.
 
-    From PyPI:
-    ```sh
-    pip install pepe-cli
-    ```
-    From Conda:
-    ```sh
-    conda install -c jahn_zhong pepe-cli
-    ```
-    Or install from the GitHub repository:
-    ```sh
-    git clone https://github.com/csi-greifflab/pepe-cli
-    cd pepe-cli
-    pip install .
-    ```
+---
 
-2. *(Optional)* For ESMC models (e.g. `biohub/ESMC-300M`), install Biohub's transformers fork:
-    ```sh
-    pip install git+https://github.com/Biohub/transformers.git@main
-    ```
+## Table of contents
 
-3. *(Optional)* For METL 1D embedding models (e.g. `metl-g-20m-1d`), install the backend directly from GitHub (it is not on PyPI):
+- [Why PEPE?](#why-pepe)
+- [Installation](#installation)
+  - [Docker](#docker)
+- [Quick start (CLI)](#quick-start-cli)
+- [Quick start (Python library)](#quick-start-python-library)
+  - [Advanced usage](#advanced-usage)
+  - [Memory management & large-scale processing](#memory-management--large-scale-processing)
+  - [Handling long sequences](#handling-long-sequences-splitting--reconstruction)
+  - [Performance optimization](#performance-optimization)
+- [Supported models](#supported-models)
+- [Arguments](#arguments)
+- [Citation](#citation)
+- [License](#license)
 
-    ```sh
-    pip install git+https://github.com/gitter-lab/metl-pretrained.git
-    ```
+---
 
-    CLI example:
+## Why PEPE?
 
-    ```sh
-    pepe --model_name metl-g-20m-1d --fasta_path <file_path> --output_path <directory> --extract_embeddings mean_pooled
-    ```
+Extracting embeddings from PLMs at scale runs into two bottlenecks: accumulating all outputs in memory before writing them to disk causes memory failures, and re-embedding the same sequences to extract different modes wastes computation. PEPE addresses both:
 
-    Library example:
+- **Multi-modal, single-pass extraction** — extract per-token, mean-pooled, and substring-pooled embeddings, plus per-head, per-layer, and per-model attention weights, from one forward pass instead of re-running the model per mode.
+- **Streaming output** — memory-mapped, concurrently written batches keep peak memory low and constant, so total output size can exceed available RAM. In practice, scaling is limited only by the write speed and capacity of your storage.
+- **Long-sequence handling** — automatic chunking and reconstruction for sequences that exceed a model's maximum input length.
+- **Broad model support** — supported PLMs, any compatible Hugging Face Hub model, and custom local PyTorch models through one interface.
+- **CLI and library** — run from the terminal or call `pepe.embed()` directly inside your own Python pipelines and notebooks.
 
-    ```python
-    import pepe
+---
 
-    results = pepe.embed(
-        model_name="metl-g-20m-1d",
-        sequences={"prot1": "MADKQKNGIKVNFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK"},
-        output_path="my_embeddings",
-        extract_embeddings=["mean_pooled"],
-        device="cpu",
-    )
-    ```
+## Installation
 
-    **Limitations:** 1D METL models only (`per_token`, `mean_pooled`, `substring_pooled`). Logits and attention outputs are not supported. 3D METL identifiers (requiring structures) and the generic Hugging Face repo id `gitter-lab/METL` are rejected—use a `metl-*-1d` identifier from [metl-pretrained](https://github.com/gitter-lab/metl-pretrained).
+From PyPI:
 
-4. Extract embeddings:\
-    Extract mean pooled embeddings from protein amino acid sequences in FASTA file:
-    ```sh
-    pepe --experiment_name <optional_string> --fasta_path <file_path> --output_path <directory> --model_name <model_name>
-    ```
+```bash
+pip install pepe-cli
+```
 
-## Quick start with Library
+From Conda:
 
-PEPE can also be used as a Python library. This allows for programmatic access to protein embeddings without using the command-line interface.
+```bash
+conda install -c jahn_zhong pepe-cli
+```
 
-1. Install PEPE (see above for details).
-2. Use the `pepe.embed()` function in your script:
+From source:
+
+```bash
+git clone https://github.com/csi-greifflab/pepe-cli
+cd pepe-cli
+pip install .
+```
+
+### Docker
+
+A pre-built image with CUDA/GPU support is published on the GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/csi-greifflab/pepe-cli:latest
+```
+
+Run PEPE from the container, passing through your GPU(s) and mounting a directory for input and output:
+
+```bash
+docker run --gpus all \
+  -v "$(pwd)":/data \
+  ghcr.io/csi-greifflab/pepe-cli:latest \
+  --model_name esm2_t33_650M_UR50D \
+  --fasta_path /data/sequences.fasta \
+  --output_path /data/embeddings
+```
+
+The `--gpus all` flag requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). Omit it to run on CPU.
+
+---
+
+## Quick start (CLI)
+
+Extract mean-pooled embeddings from sequences in a FASTA file:
+
+```bash
+pepe \
+  --model_name <model_name> \
+  --fasta_path <file_path> \
+  --output_path <directory> \
+  --experiment_name <optional_string>
+```
+
+A minimum of three options is required: `--model_name`, `--fasta_path`, and `--output_path`. Outputs are saved as NumPy arrays in a subdirectory per output type. See [Arguments](#arguments) for the full set of options.
+
+---
+
+## Quick start (Python library)
+
+PEPE can be used programmatically, giving you access to embeddings without the command-line interface.
 
 ```python
 import pepe
 
-# Example: Embed sequences from a dictionary
+# Embed sequences from a dictionary
 sequences = {
     "prot1": "MADKQKNGIKVNFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK",
-    "prot2": "MERIKELRDLMSQSRTREILTKLAEAGIDVPRLFK"
+    "prot2": "MERIKELRDLMSQSRTREILTKLAEAGIDVPRLFK",
 }
 
 results = pepe.embed(
@@ -87,205 +122,208 @@ results = pepe.embed(
     sequences=sequences,
     output_path="my_embeddings",
     extract_embeddings=["mean_pooled"],
-    device="cpu"  # Use "cuda", "cuda:0", "cuda:1", etc. if available
+    device="cpu",  # Use "cuda", "cuda:0", "cuda:1", etc. if available
 )
 
-# Or from a FASTA file
+# ...or from a FASTA file
 pepe.embed(
     model_name="facebook/esm2_t6_8M_UR50D",
-    fasta_path="path/to/fasta",
+    fasta_path="path/to/sequences.fasta",
     output_path="my_embeddings",
     extract_embeddings=["mean_pooled"],
-    device="cpu"  # Use "cuda" if available
+    device="cpu",
 )
 ```
 
-### Advanced Usage
+### Advanced usage
 
-For more control, you can use the embedder classes directly:
+For finer control, use the embedder classes directly:
 
 ```python
 from pepe.model_selecter import select_model
 
-# Select the appropriate model class
-# This acts as a factory returning the correct subclass (ESMEmbedder, HuggingfaceEmbedder, etc.)
+# Factory returning the correct subclass (ESMEmbedder, HuggingfaceEmbedder, etc.)
 ModelClass = select_model("esm2_t6_8M_UR50D")
 
-# Initialize the embedder
 embedder = ModelClass(
     model_name="facebook/esm2_t6_8M_UR50D",
     fasta_path="path/to/sequences.fasta",
     output_path="output_directory",
     extract_embeddings=["mean_pooled", "attention_head"],
-    layers=[[-1], [6]]  # Layers are expected as a list of lists of ints
+    layers=[[-1], [6]],  # Layers are expected as a list of lists of ints
 )
 
-# Run the embedding pipeline
 embedder.run()
 ```
 
-### Memory Management & Large Scale Processing
+### Memory management & large-scale processing
 
-PEPE is designed to handle protein datasets of any size by utilizing **streamed outputs** and **memory mapping**. This feature is enabled by default (`streaming_output=True`).
+PEPE handles datasets of any size using **streamed outputs** and **memory mapping**, enabled by default (`streaming_output=True`).
 
-- **CLI Usage**: No action needed. PEPE automatically streams batches to disk to avoid OOM errors.
-- **Library Usage**: When using `pepe.embed()` or the embedder classes, the returned object does **not** hold the full embeddings in RAM. Instead, it provides `numpy.memmap` handles to the data on disk.
+- **CLI**: no action needed — batches are streamed to disk automatically to avoid out-of-memory errors.
+- **Library**: the returned object does **not** hold full embeddings in RAM. It provides `numpy.memmap` handles to the data on disk.
 
 ```python
 import pepe
 
-# Returns an embedder object
 results = pepe.embed(
     model_name="facebook/esm2_t6_8M_UR50D",
     sequences=sequences,
-    output_path="large_dataset_output"
+    output_path="large_dataset_output",
     # streaming_output=True  <-- Default
 )
 
-# The embeddings are NOT loaded into RAM here.
-# 'data' is a numpy.memmap object pointing to the file on disk.
+# Embeddings are NOT loaded into RAM here.
+# 'data' is a numpy.memmap pointing to the file on disk.
 data = results.mean_pooled["output_data"][-1]
 
-# You can slice it like a normal array, which only loads those specific rows into RAM
+# Slice it like a normal array; only those rows are loaded into RAM.
 first_100_embeddings = data[:100]
 
-# Optimizing RAM usage:
-# If you are done with the model but want to keep working with the data,
-# you can delete the embedder object to free up GPU/CPU memory while keeping the memmaps.
+# Free GPU/CPU memory while keeping the memmaps by deleting the embedder object.
 del results
 ```
 
-### Handling Long Sequences (Splitting & Reconstruction)
+### Handling long sequences (splitting & reconstruction)
 
-Some models have strict architectural limits on input length (e.g., 1024 for ESM-2, 256 for AntiBERTa2). PEPE can automatically detect sequences that exceed these limits and handle them through chunking and reconstruction.
+Some models have strict input-length limits (e.g. 1024 for ESM-2, 256 for AntiBERTa2). PEPE can automatically detect sequences that exceed these limits and handle them through chunking and reconstruction.
 
-- **Automatic Detection**: When `--split_long_sequences` is enabled, PEPE automatically identifies sequences exceeding the model's capacity.
-- **Overlapping Chunks**: Use `--split_overlap` to maintain context between chunks.
-- **Reconstruction**:
-    - In **Library mode**, sequences are reconstructed in memory automatically after `embed()`.
-    - In **CLI mode**, sequences are reconstructed if `streaming_output=False`. If `streaming_output=True`, chunks are exported individually to maximize efficiency and minimize RAM usage.
+- **Automatic detection** — with `--split_long_sequences` enabled, PEPE identifies sequences exceeding the model's capacity.
+- **Overlapping chunks** — use `--split_overlap` to maintain context across chunk boundaries.
+- **Reconstruction** — in library mode, sequences are reconstructed in memory automatically after `embed()`. In CLI mode, they are reconstructed if `streaming_output=False`; if `streaming_output=True`, chunks are exported individually to maximize efficiency and minimize RAM usage.
 
 ```python
-# Library Example: Process a 2000 AA protein with ESM-2 (1024 limit)
+# Process a 2000 aa protein with ESM-2 (1024 limit)
 results = pepe.embed(
     model_name="facebook/esm2_t33_650M_UR50D",
     sequences={"long_prot": "M" * 2000},
     split_long_sequences=True,
-    split_overlap=50
+    split_overlap=50,
 )
 
-# 'results.per_token' will contain a single reconstructed tensor of length ~2002
-# (including special tokens) despite the model's 1024 limit.
+# 'results.per_token' contains a single reconstructed tensor of length ~2002
+# (including special tokens), despite the model's 1024 limit.
 ```
 
+### Performance optimization
 
-#### Performance Optimization
-
-If you have sufficient RAM to hold the entire dataset in memory, you can disable streaming output for faster execution. This avoids the overhead of writing to disk during the embedding process.
+If you have enough RAM to hold the entire dataset in memory, disable streaming output for faster execution by avoiding disk writes during embedding:
 
 ```python
 results = pepe.embed(
     model_name="facebook/esm2_t6_8M_UR50D",
     sequences=sequences,
     output_path="output",
-    streaming_output=False  # Store everything in valid RAM for speed
+    streaming_output=False,  # Keep everything in RAM for speed
 )
 
-# Now 'results.mean_pooled["output_data"]' is a standard Numpy object
-# accessible immediately in memory.
+# 'results.mean_pooled["output_data"]' is a standard NumPy object, in memory.
 ```
 
-## List of supported models:
-- ESM-family models
-    - ESM1:
-        - esm1_t34_670M_UR50S
-        - esm1_t34_670M_UR50D
-        - esm1_t34_670M_UR100
-        - esm1_t12_85M_UR50S
-        - esm1_t6_43M_UR50S
-        - esm1b_t33_650M_UR50S
-        - esm1v_t33_650M_UR90S_1
-        - esm1v_t33_650M_UR90S_2
-        - esm1v_t33_650M_UR90S_3
-        - esm1v_t33_650M_UR90S_4
-        - esm1v_t33_650M_UR90S_5
-    - ESM2:
-        - esm2_t6_8M_UR50D
-        - esm2_t12_35M_UR50D
-        - esm2_t30_150M_UR50D
-        - esm2_t33_650M_UR50D
-        - esm2_t36_3B_UR50D
-        - esm2_t48_15B_UR50D
-- Huggingface Transformer models
-    - T5 transformer models
-        - Rostlab/prot_t5_xl_half_uniref50-enc
-        - Rostlab/ProstT5
-    - RoFormer models
-        - alchemab/antiberta2-cssp
-        - alchemab/antiberta2
-    - ESMC models (requires Biohub transformers fork; see install instructions above)
-        - biohub/ESMC-300M
-        - biohub/ESMC-600M
-        - biohub/ESMC-6B
-    - METL 1D models (requires `metl-pretrained` from GitHub; see Quick start)
-        - `metl-g-20m-1d` and other `metl-*-1d` identifiers supported by [metl-pretrained](https://github.com/gitter-lab/metl-pretrained)
-    - Custom Hugging Face models
-        - Any compatible model from Hugging Face Hub: `username/model-name`
-        - Private models with authentication
-        - Local Hugging Face models
-- Custom Models
-    - Load your own PyTorch models with custom tokenizers
-    - Create example with: `python examples/custom_model/create_example_custom_model.py`
+---
 
+## Supported models
+
+**ESM-family models**
+
+- ESM-1: `esm1_t34_670M_UR50S`, `esm1_t34_670M_UR50D`, `esm1_t34_670M_UR100`, `esm1_t12_85M_UR50S`, `esm1_t6_43M_UR50S`, `esm1b_t33_650M_UR50S`, `esm1v_t33_650M_UR90S_1`, `esm1v_t33_650M_UR90S_2`, `esm1v_t33_650M_UR90S_3`, `esm1v_t33_650M_UR90S_4`, `esm1v_t33_650M_UR90S_5`
+- ESM-2: `esm2_t6_8M_UR50D`, `esm2_t12_35M_UR50D`, `esm2_t30_150M_UR50D`, `esm2_t33_650M_UR50D`, `esm2_t36_3B_UR50D`, `esm2_t48_15B_UR50D`
+
+**Hugging Face Transformer models**
+
+- T5: `Rostlab/prot_t5_xl_half_uniref50-enc`, `Rostlab/ProstT5`
+- RoFormer: `alchemab/antiberta2-cssp`, `alchemab/antiberta2`
+- Any compatible Hugging Face Hub model (`username/model-name`), including private models with authentication and local Hugging Face directories
+
+**Custom models**
+
+- Load your own PyTorch models with custom tokenizers
+- Generate a template: `python examples/custom_model/create_example_custom_model.py`
+
+---
 
 ## Arguments
 
-### Required Arguments
-- **`--model_name`** (str): Name of model or link to model. Choose from [List of supported models](../README.md#list-of-supported-models) or use custom models:
+### Required
+
+- **`--model_name`** (str): Name of the model or a path/link to one. Choose from [Supported models](#supported-models), or:
   - ESM models: `esm2_t33_650M_UR50D`
-  - ESMC models: `biohub/ESMC-300M` (requires Biohub transformers fork; see Quick start)
-  - METL 1D models: `metl-g-20m-1d` (requires `metl-pretrained` from GitHub; see Quick start)
   - Hugging Face models: `username/model-name`
   - Custom PyTorch models: `/path/to/model.pt` or `/path/to/model_directory/`
   - Local HF models: `/path/to/local_hf_directory/`
-- **`--fasta_path`** (str): Path to the input FASTA file. If no experiment name is provided, the output files will be named after the input file.
-- **`--output_path`** (str): Directory for output files. Will generate a subdirectory for outputs of each output type.
+- **`--fasta_path`** (str): Path to the input FASTA file. If no experiment name is provided, output files are named after the input file.
+- **`--output_path`** (str): Directory for output files. A subdirectory is created per output type.
 
-### Model Configuration
-- **`--tokenizer_from`** (str, optional): Huggingface address of the tokenizer to use. If not provided, will attempt to search for tokenizer packaged with model. If using a custom model, provide the path to the tokenizer directory.
-- **`--disable_special_tokens`** (bool, optional): When True, PEPE disables pre- and appending BOS/CLS and EOS/SEP tokens before embedding. Default is `False`.
-- **`--device`** (str, optional): Device to run the model on. Choose from `cuda`, `cpu`, or specific GPU indices like `cuda:0`, `cuda:1`. Default is `cuda`.
+### Model configuration
 
-### Embedding Configuration
-- **`--layers`** (str, optional): Representation layers to extract from the model. Default is the last layer. Example: `--layers -1 6`.
-- **`--extract_embeddings`** (str, optional): Set the embedding return types. Choose one or more from:
-  - `per_token`: Extracts embeddings for each token (amino acid) in the sequence. Output shape: `(num_sequences, max_length, embedding_size)`.
-  - `mean_pooled`: Computes the average embedding across all tokens in a sequence, excluding special tokens (BOS, EOS, padding). Output shape: `(num_sequences, embedding_size)`.
-  - `substring_pooled`: Computes the average embedding for a specific substring within each sequence (e.g., a CDR3 region). Requires `--substring_path`. Output shape: `(num_sequences, embedding_size)`.
-  - `attention_head`: Extracts raw attention weights for every individual head in the specified layers. Output shape: `(num_sequences, max_length, max_length)` per head.
-  - `attention_layer`: Extracts the average attention weights across all heads within each specified layer. Output shape: `(num_sequences, max_length, max_length)` per layer.
-  - `attention_model`: Extracts the average attention weights across all heads and all specified layers. Output shape: `(num_sequences, max_length, max_length)`.
-  - `logits`: Extracts the raw language model output (logits). (Experimental)
-  Default is `mean_pooled`.
-- **`--substring_path`** (str, optional): Path to a CSV file with columns "sequence_id" and "substring". Only required when selecting "substring_pooled" option.
-- **`--context`** (int, optional): Only specify when including "substring_pooled" in `--extract_embeddings` option. Number of amino acids to include before and after the substring sequence. Default is `0`.
+- **`--tokenizer_from`** (str, optional): Hugging Face address of the tokenizer. If omitted, PEPE searches for a tokenizer packaged with the model. For custom models, provide the path to the tokenizer directory.
+- **`--disable_special_tokens`** (bool, optional): When `True`, PEPE does not pre-/append BOS/CLS and EOS/SEP tokens before embedding. Default `False`.
+- **`--device`** (str, optional): Device to run the model on: `cuda`, `cpu`, or a specific index like `cuda:0`, `cuda:1`. Default `cuda`.
 
-### Processing Configuration
-- **`--batch_size`** (int, optional): Batch size for loading sequences. Default is `1024`. Decrease if encountering out-of-memory errors.
-- **`--max_length`** (int, optional): Length to which sequences will be padded. Default is length of longest sequence in input file + special token(s). If shorter than longest sequence, will forcefully default to length of longest sequence + special token(s).
-- **`--split_long_sequences`** (bool, optional): When True, automatically detect sequences exceeding the model's maximum allowed length and split them into chunks for processing. Default is `False`.
-- **`--split_overlap`** (int, optional): Number of tokens to overlap when splitting long sequences. This helps maintain context across chunk boundaries. Default is `0`.
-- **`--force_split_length`** (int, optional): Explicitly force sequence splitting at a specific length, overriding the model's auto-detected limits. Default is `None`.
-- **`--discard_padding`** (bool, optional): Discard padding tokens from per_token embeddings output. **Note**: Setting this to `True` will automatically disable `--streaming_output`. Default is `False`.
+### Embedding configuration
 
+- **`--layers`** (str, optional): Representation layers to extract. Default is the last layer. Example: `--layers -1 6`.
+- **`--extract_embeddings`** (str, optional): One or more output modes:
+  - `per_token` — embeddings for each token. Shape: `(num_sequences, max_length, embedding_size)`.
+  - `mean_pooled` — average embedding across all tokens, excluding special tokens. Shape: `(num_sequences, embedding_size)`.
+  - `substring_pooled` — average embedding for a specific substring per sequence (e.g. a CDR3 region). Requires `--substring_path`. Shape: `(num_sequences, embedding_size)`.
+  - `attention_head` — raw attention weights for every head in the specified layers. Shape: `(num_sequences, max_length, max_length)` per head.
+  - `attention_layer` — average attention across all heads within each specified layer. Shape: `(num_sequences, max_length, max_length)` per layer.
+  - `attention_model` — average attention across all heads and specified layers. Shape: `(num_sequences, max_length, max_length)`.
+  - `logits` — raw language model output (experimental).
 
-### Output Configuration
-- **`--experiment_name`** (str, optional): Prefix for names of output files. If not provided, name of input file will be used for prefix.
-- **`--streaming_output`** (bool, optional): PEPE preallocates the required disk space and writes each batch of outputs concurrently. Can pose issues with file systems that do not support memory mapping (such as some distributed file systems.)
-When False, all outputs are stored in RAM and written to disk at once after computation has finished. **Note**: Automatically disabled if `--discard_padding` is `True`. Default is `True`.
-- **`--precision`** (str, optional): Precision of the output data. Choose from `float16`, `16`, `half`, `float32`, `32`, `full`. Inference during embedding is not affected. Default is `float32`.
-- **`--flatten`** (bool, optional): Flatten 2D output arrays (per_token embeddings or attention weights) to 1D arrays per input sequence. Default is `False`.
+  Default `mean_pooled`.
+- **`--substring_path`** (str, optional): Path to a CSV with columns `sequence_id` and `substring`. Required for `substring_pooled`.
+- **`--context`** (int, optional): Number of amino acids to include before and after the substring. Only used with `substring_pooled`. Default `0`.
 
-### Performance Configuration
-- **`--num_workers`** (int, optional): Number of workers for asynchronous data writing. Only relevant when `--streaming_output` is enabled. Default is `8`.
-- **`--flush_batches_after`** (int, optional): Size (in MB) of outputs to accumulate in RAM per worker before flushing to disk. Default is `128`.
+### Processing configuration
+
+- **`--batch_size`** (int, optional): Batch size for loading sequences. Default `1024`. Decrease if you hit out-of-memory errors.
+- **`--max_length`** (int, optional): Length to pad sequences to. Defaults to the longest sequence in the input + special token(s). Values shorter than the longest sequence are forced up to that length + special token(s).
+- **`--split_long_sequences`** (bool, optional): Automatically detect and chunk sequences exceeding the model's maximum length. Default `False`.
+- **`--split_overlap`** (int, optional): Tokens to overlap when splitting long sequences, to maintain context across chunk boundaries. Default `0`.
+- **`--force_split_length`** (int, optional): Force splitting at a specific length, overriding auto-detected limits. Default `None`.
+- **`--discard_padding`** (bool, optional): Discard padding tokens from `per_token` output. **Note:** setting this to `True` automatically disables `--streaming_output`. Default `False`.
+
+### Output configuration
+
+- **`--experiment_name`** (str, optional): Prefix for output file names. Defaults to the input file name.
+- **`--streaming_output`** (bool, optional): Preallocate disk space and write each batch concurrently. May cause issues on file systems that do not support memory mapping (e.g. some distributed file systems). When `False`, all outputs are held in RAM and written at once after computation. **Note:** automatically disabled if `--discard_padding` is `True`. Default `True`.
+- **`--precision`** (str, optional): Output precision: `float16`/`16`/`half` or `float32`/`32`/`full`. Does not affect inference. Default `float32`.
+- **`--flatten`** (bool, optional): Flatten 2D output arrays (`per_token` embeddings or attention weights) to 1D per sequence. Default `False`.
+
+### Performance configuration
+
+- **`--num_workers`** (int, optional): Workers for asynchronous data writing. Only relevant with `--streaming_output`. Default `8`.
+- **`--flush_batches_after`** (int, optional): Output size (MB) accumulated in RAM per worker before flushing to disk. Default `128`.
+
+---
+
+## Citation
+
+If you use PEPE in your work, please cite:
+
+> **PEPE: Scalable extraction of multi-modal protein language model representations**
+> Jahn Zhong, Niccolò Cardente, Geir Kjetil Sandve, Habib Bashour, Maria Francesca Abbate, Victor Greiff
+> *Bioinformatics*, 2026, btag375. [https://doi.org/10.1093/bioinformatics/btag375](https://doi.org/10.1093/bioinformatics/btag375)
+
+```bibtex
+@article{zhong2026pepe,
+  title   = {PEPE: Scalable extraction of multi-modal protein language model representations},
+  author  = {Zhong, Jahn and Cardente, Niccol{\`o} and Sandve, Geir Kjetil and Bashour, Habib and Abbate, Maria Francesca and Greiff, Victor},
+  journal = {Bioinformatics},
+  year    = {2026},
+  volume  = {42},
+  number  = {6},
+  pages   = {btag375},
+  doi     = {10.1093/bioinformatics/btag375}
+}
+```
+
+The archived source is also deposited on Zenodo: [https://zenodo.org/records/15912054](https://zenodo.org/records/15912054).
+
+---
+
+## License
+
+PEPE is released under the [MIT License](https://github.com/csi-greifflab/pepe-cli/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 PEPE is a **command-line tool and Python library** for high-throughput, multi-modal extraction of representations from protein language models (PLMs). It extracts embeddings and attention matrices from protein sequences in a single parallelized, streaming pass — letting you build embedding datasets that are limited only by the write speed and capacity of your storage, not by available RAM.
 
-PEPE supports ESM-1, ESM-2, ProtT5, ProstT5, and AntiBERTa2 out of the box, along with any compatible model from the Hugging Face Hub and custom local PyTorch models.
+PEPE supports ESM-1, ESM-2, ProtT5, ProstT5, AntiBERTa2, ESMC (requires Biohub's transformers fork), and METL 1D models (requires metl-pretrained), along with any compatible model from the Hugging Face Hub and custom local PyTorch models.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -233,13 +233,17 @@ results = pepe.embed(
 
 - T5: `Rostlab/prot_t5_xl_half_uniref50-enc`, `Rostlab/ProstT5`
 - RoFormer: `alchemab/antiberta2-cssp`, `alchemab/antiberta2`
+- ESMC: `biohub/ESMC-300M`, `biohub/ESMC-600M`, `biohub/ESMC-6B` (requires Biohub's transformers fork; see Installation)
 - Any compatible Hugging Face Hub model (`username/model-name`), including private models with authentication and local Hugging Face directories
+
+**METL models**
+
+- METL 1D: `metl-*-1d` identifiers from `metl-pretrained` (requires `metl-pretrained`; logits and attention outputs are not supported)
 
 **Custom models**
 
 - Load your own PyTorch models with custom tokenizers
 - Generate a template: `python examples/custom_model/create_example_custom_model.py`
-
 ---
 
 ## Arguments

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ cd pepe-cli
 pip install .
 ```
 
+### Optional backends
+
+Some models require additional packages that are not installed by default:
+
+```bash
+# ESMC models (e.g. EvolutionaryScale/esmc-300m-2024-12) — requires Biohub's transformers fork
+pip install git+https://github.com/Biohub/transformers.git@main
+
+# METL models (e.g. metl-g-20m-1d) — requires metl-pretrained
+pip install git+https://github.com/gitter-lab/metl-pretrained.git
+```
+
 ### Docker
 
 A pre-built image with CUDA/GPU support is published on the GitHub Container Registry:


### PR DESCRIPTION
## Summary
- Replaces the legacy README with the updated published-paper version (badges, Docker install, structured docs, Bioinformatics citation, Zenodo link).
- Upgrades `actions/upload-artifact@v4` → `@v6` and `actions/download-artifact@v4` → `@v7` in the main publish workflow to resolve the Node.js 20 deprecation warning on GitHub-hosted runners.

## Test plan
- [ ] Merge and confirm the next `build-and-publish-main` run no longer shows the Node 20 deprecation warning for artifact actions.
- [ ] Review rendered README on GitHub for formatting, badges, and links.

Made with [Cursor](https://cursor.com)